### PR TITLE
Timezones

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,7 +15,25 @@ import EventModal from "../components/Modal";
 const localizer = momentLocalizer(moment);
 
 export default function Home({ events, filters }) {
+  /*
+  We set the timezone to UTC. This needs to be done
+  because react-big-calendar displays the times in
+  local time, but in the json they are read in UTC. 
+  
+  So if the json says an event is from
+  14:00 to 16:00, if we are in France in the summer
+  it would display from 16:00 to 18:00
+  
+  We don't want that, we always want
+  the same result no matter the timezone.
+
+  Bamako is the capital of Mali, which is in UTC and
+  (very important) does not implement day light savings
+
+  Refer to https://github.com/cesium/calendarium/pull/39
+  */
   moment.tz.setDefault("Africa/Bamako");
+
   const configureDates = (event) => {
     event.start = new Date(event.start);
     event.end = new Date(event.end);
@@ -118,6 +136,7 @@ export default function Home({ events, filters }) {
 }
 
 export async function getStaticProps() {
+  //Refer to the above comment
   moment.tz.setDefault("Africa/Bamako");
   const filters = JSON.parse(fs.readFileSync("data/filters.json", "utf-8"));
   const events = JSON.parse(fs.readFileSync("data/events.json", "utf-8"));

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,8 +3,7 @@ import * as fs from "fs";
 import FeedbackForm from "../components/FeedbackForm";
 import Head from "next/head";
 import { Calendar, momentLocalizer } from "react-big-calendar";
-import moment from "moment";
-import "moment/locale/en-gb";
+import moment from "moment-timezone";
 
 import styles from "../styles/Home.module.css";
 import "react-big-calendar/lib/css/react-big-calendar.css";
@@ -16,6 +15,7 @@ import EventModal from "../components/Modal";
 const localizer = momentLocalizer(moment);
 
 export default function Home({ events, filters }) {
+  moment.tz.setDefault("Africa/Bamako");
   const configureDates = (event) => {
     event.start = new Date(event.start);
     event.end = new Date(event.end);
@@ -91,8 +91,6 @@ export default function Home({ events, filters }) {
                 return { style: newStyle };
               }}
               events={Events}
-              min={new Date(2022, 0, 1, 8, 0)}
-              max={new Date(2022, 0, 1, 21, 0)}
               style={{ height: "90vh" }}
             />
           </div>
@@ -120,6 +118,7 @@ export default function Home({ events, filters }) {
 }
 
 export async function getStaticProps() {
+  moment.tz.setDefault("Africa/Bamako");
   const filters = JSON.parse(fs.readFileSync("data/filters.json", "utf-8"));
   const events = JSON.parse(fs.readFileSync("data/events.json", "utf-8"));
   return {


### PR DESCRIPTION
So this is a funny story.

Here I was, deploying this to production. The build passed. "Great success" I thought. However, a problem soon became clear. The earlier events (up until the start of November) were all taking up two days instead of one. After some digging I figured it was because times were being shifted one hour forward, meaning midnight was becoming 1 am of the next day.

I figured it was because of my browser timezone. It was. If I set it to UTC everything was fine. But that begged the question: why were only some of them being shifted. The answer lied in the fact that the unaffected events started in the beginning of November. And did you know that, here in Portugal, day light savings end on the 30th of October?

So I needed a way for the times to always be displayed in UTC, which is annoying, because all "big" countries use DLS (for some reason), and those who didn't were far from UTC. I was getting pretty annoyed. So I went googling, and did you know that Mali uses UTC and does not implement DLS?

And this is why our calendar will, from now on, display every single time as if the user were in Mali. So as long as Mali does not change its timezone, this will work.

[Remember kids, don't mess with timezones](https://www.youtube.com/watch?v=-5wpm-gesOY)