### PR TITLE
`Clear Schedule` Feature

### DIFF
--- a/components/CheckBox/CheckBox.tsx
+++ b/components/CheckBox/CheckBox.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Checkbox, Collapse } from "antd";
-import "antd/dist/antd.css";
+import "antd/dist/reset.css";
 import styles from "./checkbox.module.scss";
 import { CaretRightOutlined } from "@ant-design/icons";
 
@@ -114,7 +114,7 @@ function CheckBox({ filters, handleFilters }) {
           <Panel header={m} key={index + 1}>
             {courses[index].map((b, index1) => (
               <Collapse
-                style={{ background: "white" }}
+                className={styles.sub_checkbox}
                 bordered={false}
                 expandIcon={({ isActive }) => (
                   <CaretRightOutlined rotate={isActive ? 90 : 0} />

--- a/components/CheckBox/checkbox.module.scss
+++ b/components/CheckBox/checkbox.module.scss
@@ -27,7 +27,7 @@
 
 .sub_checkbox {
   background: white;
-  font-weight: 400;
+  font-family: Inter;
 }
 
 .filters {

--- a/components/EventModal/EventModal.tsx
+++ b/components/EventModal/EventModal.tsx
@@ -1,12 +1,10 @@
-import Modal from "@mui/material/Modal";
-import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
-import Fade from "@mui/material/Fade";
+import { Modal, Box, Typography, Grow } from "@mui/material";
 import { useState } from "react";
 
 function EventModal({
   selectedEvent: { title, place, start, end, groupId },
   setInspectEvent,
+  inspectEvent,
 }) {
   const [isModalOpen, setIsModalOpen] = useState(true);
 
@@ -25,16 +23,14 @@ function EventModal({
   });
 
   const handleModalClose = () => {
-    setIsModalOpen(false);
     setInspectEvent(false);
   };
 
   const style = {
-    position: "absolute",
+    position: "absolute" as "absolute",
     borderRadius: "30px",
     top: "50%",
     left: "50%",
-    transform: "translate(-50%, -50%)",
     width: 300,
     bgcolor: "white",
     boxShadow: 24,
@@ -44,9 +40,9 @@ function EventModal({
 
   return (
     <div>
-      <Modal open={isModalOpen} onClose={handleModalClose}>
-        <Fade in={isModalOpen}>
-          <Box sx={style}>
+      <Modal open={inspectEvent} onClose={handleModalClose}>
+        <Grow in={inspectEvent}>
+          <Box sx={style} style={{ transform: "translate(-50%, -50%)" }}>
             <Typography
               id="modal-modal-title"
               variant="h6"
@@ -92,14 +88,19 @@ function EventModal({
                 <div>
                   <p></p>
                   <i className="bi bi-link-45deg"></i>
-                  <a href="https://seium.org">seium.org</a>
+                  <a
+                    href="https://seium.org"
+                    style={{ color: "rgb(24, 144, 255, 1)" }}
+                  >
+                    seium.org
+                  </a>
                 </div>
               ) : (
                 ""
               )}
             </Typography>
           </Box>
-        </Fade>
+        </Grow>
       </Modal>
     </div>
   );

--- a/components/EventModalShift/EventModalShift.tsx
+++ b/components/EventModalShift/EventModalShift.tsx
@@ -1,7 +1,4 @@
-import Modal from "@mui/material/Modal";
-import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
-import Fade from "@mui/material/Fade";
+import { Modal, Box, Typography, Grow } from "@mui/material";
 import { useState } from "react";
 
 function EventModalShift({
@@ -18,9 +15,8 @@ function EventModalShift({
     filterId,
   },
   setInspectShift,
+  inspectShift,
 }) {
-  const [isModalOpen, setIsModalOpen] = useState(true);
-
   const start_hour = new Date(start).toLocaleTimeString("pt", {
     hour: "numeric",
     minute: "numeric",
@@ -32,7 +28,6 @@ function EventModalShift({
   });
 
   const handleModalClose = () => {
-    setIsModalOpen(false);
     setInspectShift(false);
   };
 
@@ -43,7 +38,6 @@ function EventModalShift({
     borderRadius: "30px",
     top: "50%",
     left: "50%",
-    transform: "translate(-50%, -50%)",
     width: 260,
     bgcolor: "white",
     boxShadow: 24,
@@ -56,9 +50,9 @@ function EventModalShift({
 
   return (
     <div>
-      <Modal open={isModalOpen} onClose={handleModalClose}>
-        <Fade in={isModalOpen}>
-          <Box sx={style}>
+      <Modal open={inspectShift} onClose={handleModalClose}>
+        <Grow in={inspectShift}>
+          <Box sx={style} style={{ transform: "translate(-50%, -50%)" }}>
             <Typography
               id="modal-modal-title"
               variant="h6"
@@ -89,7 +83,7 @@ function EventModalShift({
               <i className="bi bi-briefcase-fill"></i> {shift}
             </Typography>
           </Box>
-        </Fade>
+        </Grow>
       </Modal>
     </div>
   );

--- a/components/FeedbackForm/FeedbackForm.tsx
+++ b/components/FeedbackForm/FeedbackForm.tsx
@@ -7,9 +7,12 @@ const FeedbackForm = () => {
       <p className={styles.title}>
         Anything wrong or missing? <i className="bi bi-bug-fill"></i>
       </p>
-      <Link href="https://forms.gle/C2uxuUKqoeqMWfcZ6">
+      <a
+        href="https://forms.gle/C2uxuUKqoeqMWfcZ6"
+        style={{ color: "rgb(24, 144, 255, 1)" }}
+      >
         Contact us and give your feedback
-      </Link>
+      </a>
     </div>
   );
 };

--- a/components/Navbar/navbar.module.scss
+++ b/components/Navbar/navbar.module.scss
@@ -107,7 +107,7 @@
         border-radius: 3px 3px 0 0;
 
         position: absolute;
-        bottom: calc(-2rem + -2px);
+        bottom: calc(-2rem + -4px);
         left: 0;
 
         background: var(--orange);

--- a/components/SelectSchedule/SelectSchedule.tsx
+++ b/components/SelectSchedule/SelectSchedule.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Checkbox, Collapse } from "antd";
-import "antd/dist/antd.css";
+import { Checkbox, Collapse, Popconfirm } from "antd";
+import "antd/dist/reset.css";
 import { IFilterDTO } from "../../dtos";
 import styles from "./selectschedule.module.scss";
 import { CaretRightOutlined } from "@ant-design/icons";
@@ -140,15 +140,9 @@ const SelectSchedule = ({ filters, handleFilters }: ISelectScheduleProps) => {
   };
 
   function clearSelection() {
-    if (
-      confirm(
-        "Are you sure you want to clear your schedule? This will remove all your selected classes."
-      )
-    ) {
-      setSelectedFilters([]);
-      localStorage.setItem("shifts", JSON.stringify([]));
-      handleFilters([]);
-    }
+    setSelectedFilters([]);
+    localStorage.setItem("shifts", JSON.stringify([]));
+    handleFilters([]);
   }
 
   const mei = ["1ˢᵗ year"];
@@ -177,7 +171,7 @@ const SelectSchedule = ({ filters, handleFilters }: ISelectScheduleProps) => {
         <Panel header="LEI" key="panel">
           {lei.map((y, index1) => (
             <Collapse
-              style={{ background: "white" }}
+              className={styles.sub_checkbox}
               bordered={false}
               expandIcon={({ isActive }) => (
                 <CaretRightOutlined rotate={isActive ? 90 : 0} />
@@ -187,7 +181,7 @@ const SelectSchedule = ({ filters, handleFilters }: ISelectScheduleProps) => {
               <Panel header={y} key={index1}>
                 {semesters.map((s, index2) => (
                   <Collapse
-                    className={styles.sub_checkbox}
+                    className={styles.sub_sub_checkbox}
                     bordered={false}
                     expandIcon={({ isActive }) => (
                       <CaretRightOutlined rotate={isActive ? 90 : 0} />
@@ -233,7 +227,7 @@ const SelectSchedule = ({ filters, handleFilters }: ISelectScheduleProps) => {
         <Panel header="MEI" key="panel">
           {mei.map((y, index1) => (
             <Collapse
-              style={{ background: "white" }}
+              className={styles.sub_checkbox}
               bordered={false}
               expandIcon={({ isActive }) => (
                 <CaretRightOutlined rotate={isActive ? 90 : 0} />
@@ -243,7 +237,7 @@ const SelectSchedule = ({ filters, handleFilters }: ISelectScheduleProps) => {
               <Panel header={y} key={index1}>
                 {semesters.map((s, index2) => (
                   <Collapse
-                    className={styles.sub_checkbox}
+                    className={styles.sub_sub_checkbox}
                     bordered={false}
                     expandIcon={({ isActive }) => (
                       <CaretRightOutlined rotate={isActive ? 90 : 0} />
@@ -275,7 +269,7 @@ const SelectSchedule = ({ filters, handleFilters }: ISelectScheduleProps) => {
             </Collapse>
           ))}
           <Collapse
-            style={{ background: "white" }}
+            className={styles.sub_checkbox}
             bordered={false}
             expandIcon={({ isActive }) => (
               <CaretRightOutlined rotate={isActive ? 90 : 0} />
@@ -338,9 +332,26 @@ const SelectSchedule = ({ filters, handleFilters }: ISelectScheduleProps) => {
         </Panel>
       </Collapse>
 
-      <button onClick={() => clearSelection()} className={styles.clearButton}>
-        Clear Schedule <i className="bi bi-stars"></i>
-      </button>
+      <Popconfirm
+        title="Are you sure?"
+        description="This will remove all your classes"
+        onConfirm={() => {
+          clearSelection();
+        }}
+        onCancel={() => {}}
+        okText="Ok"
+        cancelText="Cancel"
+        icon={
+          <i
+            className="bi bi-exclamation-circle-fill"
+            style={{ color: "#faad14" }}
+          ></i>
+        }
+      >
+        <button className={styles.clearButton}>
+          Clear Schedule <i className="bi bi-stars"></i>
+        </button>
+      </Popconfirm>
     </div>
   );
 };

--- a/components/SelectSchedule/SelectSchedule.tsx
+++ b/components/SelectSchedule/SelectSchedule.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
 import { Checkbox, Collapse } from "antd";
 import "antd/dist/antd.css";
-import { IFilterDTO } from "../dtos";
-import styles from "../components/CheckBox/checkbox.module.scss";
+import { IFilterDTO } from "../../dtos";
+import styles from "./selectschedule.module.scss";
 import { CaretRightOutlined } from "@ant-design/icons";
+import { clear } from "console";
 
 const { Panel } = Collapse;
 
@@ -64,10 +65,7 @@ const Option = ({ filter, handleToggle, isChecked }: IOptionProps) => (
   </>
 );
 
-export const SelectSchedule = ({
-  filters,
-  handleFilters,
-}: ISelectScheduleProps) => {
+const SelectSchedule = ({ filters, handleFilters }: ISelectScheduleProps) => {
   // Initial state for the CheckBox and the update function
   const [selectedFilters, setSelectedFilters] = useState<ISelectedFilter[]>([]);
   React.useEffect(() => {
@@ -142,6 +140,18 @@ export const SelectSchedule = ({
     handleFilters(newSelctedFilters);
   };
 
+  function clearSelection() {
+    if (
+      confirm(
+        "Are you sure you want to clear your schedule? This will remove all your selected classes."
+      )
+    ) {
+      setSelectedFilters([]);
+      localStorage.setItem("shifts", JSON.stringify([]));
+      handleFilters([]);
+    }
+  }
+
   const mei = ["1ˢᵗ year"];
 
   const lei = ["1ˢᵗ year", "2ⁿᵈ year", "3ʳᵈ year"];
@@ -155,7 +165,7 @@ export const SelectSchedule = ({
   };
 
   return (
-    <div className={styles.layer}>
+    <div className={styles.filters}>
       {/* LEI */}
 
       <Collapse
@@ -328,6 +338,12 @@ export const SelectSchedule = ({
           )}
         </Panel>
       </Collapse>
+
+      <button onClick={() => clearSelection()} className={styles.clearButton}>
+        Clear Schedule <i className="bi bi-stars"></i>
+      </button>
     </div>
   );
 };
+
+export default SelectSchedule;

--- a/components/SelectSchedule/SelectSchedule.tsx
+++ b/components/SelectSchedule/SelectSchedule.tsx
@@ -4,7 +4,6 @@ import "antd/dist/antd.css";
 import { IFilterDTO } from "../../dtos";
 import styles from "./selectschedule.module.scss";
 import { CaretRightOutlined } from "@ant-design/icons";
-import { clear } from "console";
 
 const { Panel } = Collapse;
 

--- a/components/SelectSchedule/index.ts
+++ b/components/SelectSchedule/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SelectSchedule";

--- a/components/SelectSchedule/selectschedule.module.scss
+++ b/components/SelectSchedule/selectschedule.module.scss
@@ -1,0 +1,77 @@
+.filters {
+  position: absolute;
+  z-index: 1;
+  padding: 0 2rem;
+  left: 0;
+  width: 100%;
+  padding-bottom: 4.9rem;
+}
+
+.clearButton {
+  position: absolute;
+  display: inline;
+  right: 3rem;
+
+  background: rgba(73, 103, 255, 0.9);
+  border-radius: 25px;
+  box-sizing: border-box;
+  color: white;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Inter;
+  font-weight: 500;
+  line-height: 24px;
+  opacity: 1;
+  outline: 0 solid transparent;
+  padding: 8px 16px;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+  width: fit-content;
+  word-break: break-word;
+  border: 0;
+  margin: 2px 0 0 0;
+  transition: 150ms linear;
+  padding: 0.6rem;
+
+  box-shadow: 0 0px 10px rgba(0, 0, 0, 0.22);
+
+  &:hover {
+    box-shadow: rgb(73, 103, 255, 0.8) 0 2px 12px 0px;
+  }
+}
+
+.checkbox {
+  display: inline-flex;
+  border-radius: 25px;
+  box-shadow: 0 0px 10px rgba(0, 0, 0, 0.18);
+  font-family: Inter;
+  font-size: 15px;
+  font-weight: 500;
+  width: 16rem;
+  background: white;
+  margin: 0 1rem 1rem 0;
+}
+
+.sub_checkbox {
+  background: white;
+  font-weight: 400;
+}
+
+@media (max-width: 1070px) {
+  .filters {
+    position: relative;
+    padding: 0;
+  }
+  .checkbox {
+    display: inline-block;
+    width: 100%;
+  }
+  .clearButton {
+    position: relative;
+    display: inline-block;
+    width: 100%;
+    margin: 0 0 1rem 0;
+    right: 0;
+  }
+}

--- a/components/SelectSchedule/selectschedule.module.scss
+++ b/components/SelectSchedule/selectschedule.module.scss
@@ -10,7 +10,7 @@
 .clearButton {
   position: absolute;
   display: inline;
-  right: 3rem;
+  right: 2rem;
 
   background: rgba(73, 103, 255, 0.9);
   border-radius: 25px;
@@ -54,6 +54,11 @@
 }
 
 .sub_checkbox {
+  background: white;
+  font-family: Inter;
+}
+
+.sub_sub_checkbox {
   background: white;
   font-weight: 400;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@emotion/styled": "^11.10.5",
         "@mui/material": "^5.11.6",
         "@types/react-big-calendar": "^0.38.1",
-        "antd": "^4.22.1",
+        "antd": "^5.1.0",
         "emailjs": "^4.0.0",
         "emailjs-com": "^3.2.0",
         "html2canvas": "^1.4.1",
@@ -56,19 +56,47 @@
       }
     },
     "node_modules/@ant-design/colors": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-6.0.0.tgz",
-      "integrity": "sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.0.0.tgz",
+      "integrity": "sha512-iVm/9PfGCbC0dSMBrz7oiEXZaaGH7ceU40OJEfKmyuzR9R5CRimJYPlRiFtMQGQcbNMea/ePcoIebi4ASGYXtg==",
       "dependencies": {
         "@ctrl/tinycolor": "^3.4.0"
       }
     },
-    "node_modules/@ant-design/icons": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.7.0.tgz",
-      "integrity": "sha512-aoB4Z7JA431rt6d4u+8xcNPPCrdufSRMUOpxa1ab6mz1JCQZOEVolj2WVs/tDFmN62zzK30mNelEsprLYsSF3g==",
+    "node_modules/@ant-design/cssinjs": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.5.6.tgz",
+      "integrity": "sha512-1S7LUPC9BMyQ/CUYgzfePJJwEfsbVHJe3Tpd9zhujTxRM/6LYpN9N4FTaPHVqpnPazm0S2vG0WBkh2T5Erwuug==",
       "dependencies": {
-        "@ant-design/colors": "^6.0.0",
+        "@babel/runtime": "^7.11.1",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/unitless": "^0.7.5",
+        "classnames": "^2.3.1",
+        "csstype": "^3.0.10",
+        "rc-util": "^5.27.0",
+        "stylis": "^4.0.13"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@ant-design/cssinjs/node_modules/@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "node_modules/@ant-design/cssinjs/node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "node_modules/@ant-design/icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.0.1.tgz",
+      "integrity": "sha512-ZyF4ksXCcdtwA/1PLlnFLcF/q8/MhwxXhKHh4oCHDA4Ip+ZzAHoICtyp4wZWfiCVDP0yuz3HsjyvuldHFb3wjA==",
+      "dependencies": {
+        "@ant-design/colors": "^7.0.0",
         "@ant-design/icons-svg": "^4.2.1",
         "@babel/runtime": "^7.11.2",
         "classnames": "^2.2.6",
@@ -88,15 +116,15 @@
       "integrity": "sha512-EB0iwlKDGpG93hW8f85CTJTs4SvMX7tt5ceupvhALp1IF44SeUFOMhKUOYqpsoYWQKAOuTRDMqn75rEaKDp0Xw=="
     },
     "node_modules/@ant-design/react-slick": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-0.29.2.tgz",
-      "integrity": "sha512-kgjtKmkGHa19FW21lHnAfyyH9AAoh35pBdcJ53rHmQ3O+cfFHGHnUbj/HFrRNJ5vIts09FKJVAD8RpaC+RaWfA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-1.0.0.tgz",
+      "integrity": "sha512-OKxZsn8TAf8fYxP79rDXgLs9zvKMTslK6dJ4iLhDXOujUqC5zJPBRszyrcEHXcMPOm1Sgk40JgyF3yiL/Swd7w==",
       "dependencies": {
         "@babel/runtime": "^7.10.4",
         "classnames": "^2.2.5",
         "json2mq": "^0.2.0",
-        "lodash": "^4.17.21",
-        "resize-observer-polyfill": "^1.5.1"
+        "resize-observer-polyfill": "^1.5.1",
+        "throttle-debounce": "^5.0.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0"
@@ -477,9 +505,9 @@
       }
     },
     "node_modules/@ctrl/tinycolor": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.1.tgz",
-      "integrity": "sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.5.0.tgz",
+      "integrity": "sha512-tlJpwF40DEQcfR/QF+wNMVyGMaO9FQp6Z1Wahj4Gk3CJQYHwA2xVG7iKDFdW6zuxZY9XWOpGcfNCTsX4McOsOg==",
       "engines": {
         "node": ">=10"
       }
@@ -1247,6 +1275,47 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@rc-component/context": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-1.3.0.tgz",
+      "integrity": "sha512-6QdaCJ7Wn5UZLJs15IEfqy4Ru3OaL5ctqpQYWd5rlfV9wwzrzdt6+kgAQZV/qdB0MUPN4nhyBfRembQCIvBf+w==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "rc-util": "^5.27.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/mini-decimal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.0.1.tgz",
+      "integrity": "sha512-9N8nRk0oKj1qJzANKl+n9eNSMUGsZtjwNuDCiZ/KA+dt1fE3zq5x2XxclRcAbOIXnZcJ53ozP2Pa60gyELXagA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
+    "node_modules/@rc-component/mutate-observer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-1.0.0.tgz",
+      "integrity": "sha512-okqRJSfNisXdI6CUeOLZC5ukBW/8kir2Ii4PJiKpUt+3+uS7dxwJUMxsUZquxA1rQuL8YcEmKVp/TCnR+yUdZA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
     "node_modules/@rc-component/portal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.0.tgz",
@@ -1254,6 +1323,25 @@
       "dependencies": {
         "@babel/runtime": "^7.18.0",
         "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/tour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.1.0.tgz",
+      "integrity": "sha512-Cy45VnNEDq6DLF5eKonIflObDfofbPq7AJpSf18qLN+j9+wW+sNlRv3JnCMDUsCdhSlnM4+yJ1RMokKp9GCpOQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "@rc-component/portal": "^1.0.0-9",
+        "classnames": "^2.3.2",
+        "rc-trigger": "^5.3.4",
         "rc-util": "^5.24.4"
       },
       "engines": {
@@ -1780,53 +1868,57 @@
       }
     },
     "node_modules/antd": {
-      "version": "4.24.7",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-4.24.7.tgz",
-      "integrity": "sha512-Qr3AYkeqpd3i/c6M7pjca7Y6XlaIv/p6gD3aqe7/0o8Ueg50G7Aeh+TOaiUfXLGDhnVoNEdaVdDiv8aIaoWB5A==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.1.7.tgz",
+      "integrity": "sha512-rz7wrUPWfE1WAt7o8vlTmjfxVmbV0Vyh00PEO8F837Gq0wugvOiWVPJ4BI/piIxUIpKXASYmCYWOczoHCkwBMQ==",
       "dependencies": {
-        "@ant-design/colors": "^6.0.0",
-        "@ant-design/icons": "^4.7.0",
-        "@ant-design/react-slick": "~0.29.1",
+        "@ant-design/colors": "^7.0.0",
+        "@ant-design/cssinjs": "^1.5.6",
+        "@ant-design/icons": "^5.0.0",
+        "@ant-design/react-slick": "~1.0.0",
         "@babel/runtime": "^7.18.3",
         "@ctrl/tinycolor": "^3.4.0",
+        "@rc-component/mutate-observer": "^1.0.0",
+        "@rc-component/tour": "~1.1.0",
         "classnames": "^2.2.6",
         "copy-to-clipboard": "^3.2.0",
-        "lodash": "^4.17.21",
-        "moment": "^2.29.2",
-        "rc-cascader": "~3.7.0",
+        "dayjs": "^1.11.1",
+        "qrcode.react": "^3.1.0",
+        "rc-cascader": "~3.8.0",
         "rc-checkbox": "~2.3.0",
         "rc-collapse": "~3.4.2",
         "rc-dialog": "~9.0.2",
-        "rc-drawer": "~6.1.0",
+        "rc-drawer": "~6.1.1",
         "rc-dropdown": "~4.0.0",
         "rc-field-form": "~1.27.0",
         "rc-image": "~5.13.0",
         "rc-input": "~0.1.4",
-        "rc-input-number": "~7.3.9",
+        "rc-input-number": "~7.4.0",
         "rc-mentions": "~1.13.1",
-        "rc-menu": "~9.8.0",
+        "rc-menu": "~9.8.2",
         "rc-motion": "^2.6.1",
-        "rc-notification": "~4.6.0",
+        "rc-notification": "~5.0.0",
         "rc-pagination": "~3.2.0",
-        "rc-picker": "~2.7.0",
+        "rc-picker": "~3.1.1",
         "rc-progress": "~3.4.1",
         "rc-rate": "~2.9.0",
         "rc-resize-observer": "^1.2.0",
         "rc-segmented": "~2.1.0",
-        "rc-select": "~14.1.13",
+        "rc-select": "~14.2.0",
         "rc-slider": "~10.0.0",
-        "rc-steps": "~5.0.0-alpha.2",
-        "rc-switch": "~3.2.0",
-        "rc-table": "~7.26.0",
-        "rc-tabs": "~12.5.0",
+        "rc-steps": "~6.0.0",
+        "rc-switch": "~4.0.0",
+        "rc-table": "~7.30.2",
+        "rc-tabs": "~12.5.1",
         "rc-textarea": "~0.4.5",
         "rc-tooltip": "~5.2.0",
         "rc-tree": "~5.7.0",
-        "rc-tree-select": "~5.5.0",
-        "rc-trigger": "^5.2.10",
+        "rc-tree-select": "~5.6.0",
+        "rc-trigger": "^5.3.4",
         "rc-upload": "~4.3.0",
-        "rc-util": "^5.22.5",
-        "scroll-into-view-if-needed": "^2.2.25"
+        "rc-util": "^5.27.0",
+        "scroll-into-view-if-needed": "^3.0.3",
+        "throttle-debounce": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2388,9 +2480,9 @@
       }
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
-      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz",
+      "integrity": "sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2531,18 +2623,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
       "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg=="
-    },
-    "node_modules/date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
     },
     "node_modules/dayjs": {
       "version": "1.11.7",
@@ -5551,6 +5631,14 @@
         "purgecss": "bin/purgecss.js"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.1.0.tgz",
+      "integrity": "sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5618,14 +5706,14 @@
       }
     },
     "node_modules/rc-cascader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.7.0.tgz",
-      "integrity": "sha512-SFtGpwmYN7RaWEAGTS4Rkc62ZV/qmQGg/tajr/7mfIkleuu8ro9Hlk6J+aA0x1YS4zlaZBtTcSaXM01QMiEV/A==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.8.0.tgz",
+      "integrity": "sha512-zCz/NzsNRQ1TIfiR3rQNxjeRvgRHEkNdo0FjHQZ6Ay6n4tdCmMrM7+81ThNaf21JLQ1gS2AUG2t5uikGV78obA==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "array-tree-filter": "^2.1.0",
         "classnames": "^2.3.1",
-        "rc-select": "~14.1.0",
+        "rc-select": "~14.2.0",
         "rc-tree": "~5.7.0",
         "rc-util": "^5.6.1"
       },
@@ -5759,11 +5847,12 @@
       }
     },
     "node_modules/rc-input-number": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.3.11.tgz",
-      "integrity": "sha512-aMWPEjFeles6PQnMqP5eWpxzsvHm9rh1jQOWXExUEIxhX62Fyl/ptifLHOn17+waDG1T/YUb6flfJbvwRhHrbA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.4.0.tgz",
+      "integrity": "sha512-r/Oub/sPYbzqLNUOHnnc9sbCu78a81KX+RCbRwmpvB4W6nptUySbdWS5KHV4Hak5CAE1LAd+wWm5JjvZizG1FA==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/mini-decimal": "^1.0.1",
         "classnames": "^2.2.5",
         "rc-util": "^5.23.0"
       },
@@ -5790,17 +5879,16 @@
       }
     },
     "node_modules/rc-menu": {
-      "version": "9.8.1",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.8.1.tgz",
-      "integrity": "sha512-179weouypfjWJSRvvoo/vPy+StojsMzK2XC5jRNhL1ryt/N/8wAFESte8K6jZJkNp9DHDLFTe+dCGmikKpiFuA==",
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.8.2.tgz",
+      "integrity": "sha512-EahOJVjLuEnJsThoPN+mGnVm431RzVzDLZWHRS/YnXTQULa7OsgdJa/Y7qXxc3Z5sz8mgT6xYtgpmBXLxrZFaQ==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
         "rc-motion": "^2.4.3",
         "rc-overflow": "^1.2.8",
         "rc-trigger": "^5.1.2",
-        "rc-util": "^5.12.0",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.27.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -5822,13 +5910,13 @@
       }
     },
     "node_modules/rc-notification": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-4.6.0.tgz",
-      "integrity": "sha512-xF3MKgIoynzjQAO4lqsoraiFo3UXNYlBfpHs0VWvwF+4pimen9/H1DYLN2mfRWhHovW6gRpla73m2nmyIqAMZQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.0.2.tgz",
+      "integrity": "sha512-74wUFiLlyr6lRGEY1m1BaTiDp+0lIT4FRAblMnh9FApyK2JGdsSLbrQ/1rgM7d2N/IX5UIr8kLLW3TdXxFt/jQ==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "rc-motion": "^2.2.0",
+        "rc-motion": "^2.6.0",
         "rc-util": "^5.20.1"
       },
       "engines": {
@@ -5868,25 +5956,35 @@
       }
     },
     "node_modules/rc-picker": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-2.7.0.tgz",
-      "integrity": "sha512-oZH6FZ3j4iuBxHB4NvQ6ABRsS2If/Kpty1YFFsji7/aej6ruGmfM7WnJWQ88AoPfpJ++ya5z+nVEA8yCRYGKyw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-3.1.5.tgz",
+      "integrity": "sha512-Hh3ml+u+5mxLfl4ahVWlRGiX5+0EJrALR6tSW9yP0eea+6j+YjvjfetbvuVidViMDMweZa38dr8HTfAFLG6GFw==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
-        "date-fns": "2.x",
-        "dayjs": "1.x",
-        "moment": "^2.24.0",
         "rc-trigger": "^5.0.4",
-        "rc-util": "^5.4.0",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.27.0"
       },
       "engines": {
         "node": ">=8.x"
       },
       "peerDependencies": {
+        "date-fns": ">= 2.x",
+        "dayjs": ">= 1.x",
+        "moment": ">= 2.x",
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "date-fns": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        }
       }
     },
     "node_modules/rc-progress": {
@@ -5951,9 +6049,9 @@
       }
     },
     "node_modules/rc-select": {
-      "version": "14.1.16",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.1.16.tgz",
-      "integrity": "sha512-71XLHleuZmufpdV2vis5oituRkhg2WNvLpVMJBGWRar6WGAVOHXaY9DR5HvwWry3EGTn19BqnL6Xbybje6f8YA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.2.0.tgz",
+      "integrity": "sha512-tvxHmbAA0EIhBkB7dyaRhcBUIWHocQbUFY/fBlezj2jg5p65a5VQ/UhBg2I9TA1wjpsr5CCx0ruZPkYcUMjDoQ==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -5961,7 +6059,7 @@
         "rc-overflow": "^1.0.0",
         "rc-trigger": "^5.0.4",
         "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.2.0"
+        "rc-virtual-list": "^3.4.13"
       },
       "engines": {
         "node": ">=8.x"
@@ -5990,9 +6088,9 @@
       }
     },
     "node_modules/rc-steps": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-5.0.0.tgz",
-      "integrity": "sha512-9TgRvnVYirdhbV0C3syJFj9EhCRqoJAsxt4i1rED5o8/ZcSv5TLIYyo4H8MCjLPvbe2R+oBAm/IYBEtC+OS1Rw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-6.0.0.tgz",
+      "integrity": "sha512-+KfMZIty40mYCQSDvYbZ1jwnuObLauTiIskT1hL4FFOBHP6ZOr8LK0m143yD3kEN5XKHSEX1DIwCj3AYZpoeNQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.7",
         "classnames": "^2.2.3",
@@ -6007,9 +6105,9 @@
       }
     },
     "node_modules/rc-switch": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-3.2.2.tgz",
-      "integrity": "sha512-+gUJClsZZzvAHGy1vZfnwySxj+MjLlGRyXKXScrtCTcmiYNPzxDFOxdQ/3pK1Kt/0POvwJ/6ALOR8gwdXGhs+A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-4.0.0.tgz",
+      "integrity": "sha512-IfrYC99vN0gKaTyjQdqYuADU0eH00SAFHg3jOp8HrmUpJruhV1SohJzrCbPqPraZeX/6X/QKkdLfkdnUub05WA==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
@@ -6021,15 +6119,15 @@
       }
     },
     "node_modules/rc-table": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.26.0.tgz",
-      "integrity": "sha512-0cD8e6S+DTGAt5nBZQIPFYEaIukn17sfa5uFL98faHlH/whZzD8ii3dbFL4wmUDEL4BLybhYop+QUfZJ4CPvNQ==",
+      "version": "7.30.3",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.30.3.tgz",
+      "integrity": "sha512-PHe+lZKwPo3qui5j79m54vKu8b4hebk04x+4Hy65NvwUU3+NNFGS5FZpylXQMkueMnE8hgh22ZuScQDkCtzQFQ==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/context": "^1.3.0",
         "classnames": "^2.2.5",
         "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.22.5",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.27.1"
       },
       "engines": {
         "node": ">=8.x"
@@ -6110,13 +6208,13 @@
       }
     },
     "node_modules/rc-tree-select": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.5.5.tgz",
-      "integrity": "sha512-k2av7jF6tW9bIO4mQhaVdV4kJ1c54oxV3/hHVU+oD251Gb5JN+m1RbJFTMf1o0rAFqkvto33rxMdpafaGKQRJw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.6.0.tgz",
+      "integrity": "sha512-XG6pu0a9l6+mzhQqUYfR2VIONbe/3LjVc3wKt28k6uBMZsI1j+SSxRyt/7jWRq8Kok8jHJBQASlDg6ehr9Sp0w==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "rc-select": "~14.1.0",
+        "rc-select": "~14.2.0",
         "rc-tree": "~5.7.0",
         "rc-util": "^5.16.1"
       },
@@ -6126,9 +6224,9 @@
       }
     },
     "node_modules/rc-trigger": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.3.1.tgz",
-      "integrity": "sha512-5gaFbDkYSefZ14j2AdzucXzlWgU2ri5uEjkHvsf1ynRhdJbKxNOnw4PBZ9+FVULNGFiDzzlVF8RJnR9P/xrnKQ==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.3.4.tgz",
+      "integrity": "sha512-mQv+vas0TwKcjAO2izNPkqR4j86OemLRmvL2nOzdP9OWNWA1ivoTt5hzFqYNW9zACwmTezRiN8bttrC7cZzYSw==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "classnames": "^2.2.6",
@@ -6655,11 +6753,11 @@
       }
     },
     "node_modules/scroll-into-view-if-needed": {
-      "version": "2.2.29",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.29.tgz",
-      "integrity": "sha512-hxpAR6AN+Gh53AdAimHM6C8oTN1ppwVZITihix+WqalywBeFcQ6LdQP5ABNl26nX8GTEL7VT+b8lKpdqq65wXg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.0.4.tgz",
+      "integrity": "sha512-s+/F50jwTOUt+u5oEIAzum9MN2lUQNvWBe/zfEsVQcbaERjGkKLq1s+2wCHkahMLC8nMLbzMVKivx9JhunXaZg==",
       "dependencies": {
-        "compute-scroll-into-view": "^1.0.17"
+        "compute-scroll-into-view": "^2.0.4"
       }
     },
     "node_modules/semver": {
@@ -7498,6 +7596,14 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/throttle-debounce": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+      "integrity": "sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==",
+      "engines": {
+        "node": ">=12.22"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
@@ -7954,19 +8060,45 @@
       }
     },
     "@ant-design/colors": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-6.0.0.tgz",
-      "integrity": "sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.0.0.tgz",
+      "integrity": "sha512-iVm/9PfGCbC0dSMBrz7oiEXZaaGH7ceU40OJEfKmyuzR9R5CRimJYPlRiFtMQGQcbNMea/ePcoIebi4ASGYXtg==",
       "requires": {
         "@ctrl/tinycolor": "^3.4.0"
       }
     },
-    "@ant-design/icons": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.7.0.tgz",
-      "integrity": "sha512-aoB4Z7JA431rt6d4u+8xcNPPCrdufSRMUOpxa1ab6mz1JCQZOEVolj2WVs/tDFmN62zzK30mNelEsprLYsSF3g==",
+    "@ant-design/cssinjs": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.5.6.tgz",
+      "integrity": "sha512-1S7LUPC9BMyQ/CUYgzfePJJwEfsbVHJe3Tpd9zhujTxRM/6LYpN9N4FTaPHVqpnPazm0S2vG0WBkh2T5Erwuug==",
       "requires": {
-        "@ant-design/colors": "^6.0.0",
+        "@babel/runtime": "^7.11.1",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/unitless": "^0.7.5",
+        "classnames": "^2.3.1",
+        "csstype": "^3.0.10",
+        "rc-util": "^5.27.0",
+        "stylis": "^4.0.13"
+      },
+      "dependencies": {
+        "@emotion/hash": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+          "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+        },
+        "@emotion/unitless": {
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+          "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+        }
+      }
+    },
+    "@ant-design/icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.0.1.tgz",
+      "integrity": "sha512-ZyF4ksXCcdtwA/1PLlnFLcF/q8/MhwxXhKHh4oCHDA4Ip+ZzAHoICtyp4wZWfiCVDP0yuz3HsjyvuldHFb3wjA==",
+      "requires": {
+        "@ant-design/colors": "^7.0.0",
         "@ant-design/icons-svg": "^4.2.1",
         "@babel/runtime": "^7.11.2",
         "classnames": "^2.2.6",
@@ -7979,15 +8111,15 @@
       "integrity": "sha512-EB0iwlKDGpG93hW8f85CTJTs4SvMX7tt5ceupvhALp1IF44SeUFOMhKUOYqpsoYWQKAOuTRDMqn75rEaKDp0Xw=="
     },
     "@ant-design/react-slick": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-0.29.2.tgz",
-      "integrity": "sha512-kgjtKmkGHa19FW21lHnAfyyH9AAoh35pBdcJ53rHmQ3O+cfFHGHnUbj/HFrRNJ5vIts09FKJVAD8RpaC+RaWfA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-1.0.0.tgz",
+      "integrity": "sha512-OKxZsn8TAf8fYxP79rDXgLs9zvKMTslK6dJ4iLhDXOujUqC5zJPBRszyrcEHXcMPOm1Sgk40JgyF3yiL/Swd7w==",
       "requires": {
         "@babel/runtime": "^7.10.4",
         "classnames": "^2.2.5",
         "json2mq": "^0.2.0",
-        "lodash": "^4.17.21",
-        "resize-observer-polyfill": "^1.5.1"
+        "resize-observer-polyfill": "^1.5.1",
+        "throttle-debounce": "^5.0.0"
       }
     },
     "@babel/code-frame": {
@@ -8268,9 +8400,9 @@
       "requires": {}
     },
     "@ctrl/tinycolor": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.1.tgz",
-      "integrity": "sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.5.0.tgz",
+      "integrity": "sha512-tlJpwF40DEQcfR/QF+wNMVyGMaO9FQp6Z1Wahj4Gk3CJQYHwA2xVG7iKDFdW6zuxZY9XWOpGcfNCTsX4McOsOg=="
     },
     "@emotion/babel-plugin": {
       "version": "11.10.5",
@@ -8718,6 +8850,33 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
+    "@rc-component/context": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-1.3.0.tgz",
+      "integrity": "sha512-6QdaCJ7Wn5UZLJs15IEfqy4Ru3OaL5ctqpQYWd5rlfV9wwzrzdt6+kgAQZV/qdB0MUPN4nhyBfRembQCIvBf+w==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "rc-util": "^5.27.0"
+      }
+    },
+    "@rc-component/mini-decimal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.0.1.tgz",
+      "integrity": "sha512-9N8nRk0oKj1qJzANKl+n9eNSMUGsZtjwNuDCiZ/KA+dt1fE3zq5x2XxclRcAbOIXnZcJ53ozP2Pa60gyELXagA==",
+      "requires": {
+        "@babel/runtime": "^7.18.0"
+      }
+    },
+    "@rc-component/mutate-observer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-1.0.0.tgz",
+      "integrity": "sha512-okqRJSfNisXdI6CUeOLZC5ukBW/8kir2Ii4PJiKpUt+3+uS7dxwJUMxsUZquxA1rQuL8YcEmKVp/TCnR+yUdZA==",
+      "requires": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      }
+    },
     "@rc-component/portal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.0.tgz",
@@ -8725,6 +8884,18 @@
       "requires": {
         "@babel/runtime": "^7.18.0",
         "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      }
+    },
+    "@rc-component/tour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.1.0.tgz",
+      "integrity": "sha512-Cy45VnNEDq6DLF5eKonIflObDfofbPq7AJpSf18qLN+j9+wW+sNlRv3JnCMDUsCdhSlnM4+yJ1RMokKp9GCpOQ==",
+      "requires": {
+        "@babel/runtime": "^7.18.0",
+        "@rc-component/portal": "^1.0.0-9",
+        "classnames": "^2.3.2",
+        "rc-trigger": "^5.3.4",
         "rc-util": "^5.24.4"
       }
     },
@@ -9160,53 +9331,57 @@
       }
     },
     "antd": {
-      "version": "4.24.7",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-4.24.7.tgz",
-      "integrity": "sha512-Qr3AYkeqpd3i/c6M7pjca7Y6XlaIv/p6gD3aqe7/0o8Ueg50G7Aeh+TOaiUfXLGDhnVoNEdaVdDiv8aIaoWB5A==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.1.7.tgz",
+      "integrity": "sha512-rz7wrUPWfE1WAt7o8vlTmjfxVmbV0Vyh00PEO8F837Gq0wugvOiWVPJ4BI/piIxUIpKXASYmCYWOczoHCkwBMQ==",
       "requires": {
-        "@ant-design/colors": "^6.0.0",
-        "@ant-design/icons": "^4.7.0",
-        "@ant-design/react-slick": "~0.29.1",
+        "@ant-design/colors": "^7.0.0",
+        "@ant-design/cssinjs": "^1.5.6",
+        "@ant-design/icons": "^5.0.0",
+        "@ant-design/react-slick": "~1.0.0",
         "@babel/runtime": "^7.18.3",
         "@ctrl/tinycolor": "^3.4.0",
+        "@rc-component/mutate-observer": "^1.0.0",
+        "@rc-component/tour": "~1.1.0",
         "classnames": "^2.2.6",
         "copy-to-clipboard": "^3.2.0",
-        "lodash": "^4.17.21",
-        "moment": "^2.29.2",
-        "rc-cascader": "~3.7.0",
+        "dayjs": "^1.11.1",
+        "qrcode.react": "^3.1.0",
+        "rc-cascader": "~3.8.0",
         "rc-checkbox": "~2.3.0",
         "rc-collapse": "~3.4.2",
         "rc-dialog": "~9.0.2",
-        "rc-drawer": "~6.1.0",
+        "rc-drawer": "~6.1.1",
         "rc-dropdown": "~4.0.0",
         "rc-field-form": "~1.27.0",
         "rc-image": "~5.13.0",
         "rc-input": "~0.1.4",
-        "rc-input-number": "~7.3.9",
+        "rc-input-number": "~7.4.0",
         "rc-mentions": "~1.13.1",
-        "rc-menu": "~9.8.0",
+        "rc-menu": "~9.8.2",
         "rc-motion": "^2.6.1",
-        "rc-notification": "~4.6.0",
+        "rc-notification": "~5.0.0",
         "rc-pagination": "~3.2.0",
-        "rc-picker": "~2.7.0",
+        "rc-picker": "~3.1.1",
         "rc-progress": "~3.4.1",
         "rc-rate": "~2.9.0",
         "rc-resize-observer": "^1.2.0",
         "rc-segmented": "~2.1.0",
-        "rc-select": "~14.1.13",
+        "rc-select": "~14.2.0",
         "rc-slider": "~10.0.0",
-        "rc-steps": "~5.0.0-alpha.2",
-        "rc-switch": "~3.2.0",
-        "rc-table": "~7.26.0",
-        "rc-tabs": "~12.5.0",
+        "rc-steps": "~6.0.0",
+        "rc-switch": "~4.0.0",
+        "rc-table": "~7.30.2",
+        "rc-tabs": "~12.5.1",
         "rc-textarea": "~0.4.5",
         "rc-tooltip": "~5.2.0",
         "rc-tree": "~5.7.0",
-        "rc-tree-select": "~5.5.0",
-        "rc-trigger": "^5.2.10",
+        "rc-tree-select": "~5.6.0",
+        "rc-trigger": "^5.3.4",
         "rc-upload": "~4.3.0",
-        "rc-util": "^5.22.5",
-        "scroll-into-view-if-needed": "^2.2.25"
+        "rc-util": "^5.27.0",
+        "scroll-into-view-if-needed": "^3.0.3",
+        "throttle-debounce": "^5.0.0"
       }
     },
     "anymatch": {
@@ -9597,9 +9772,9 @@
       "dev": true
     },
     "compute-scroll-into-view": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
-      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz",
+      "integrity": "sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -9708,11 +9883,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
       "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg=="
-    },
-    "date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
     },
     "dayjs": {
       "version": "1.11.7",
@@ -11890,6 +12060,12 @@
         "postcss-selector-parser": "^6.0.6"
       }
     },
+    "qrcode.react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.1.0.tgz",
+      "integrity": "sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==",
+      "requires": {}
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -11933,14 +12109,14 @@
       }
     },
     "rc-cascader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.7.0.tgz",
-      "integrity": "sha512-SFtGpwmYN7RaWEAGTS4Rkc62ZV/qmQGg/tajr/7mfIkleuu8ro9Hlk6J+aA0x1YS4zlaZBtTcSaXM01QMiEV/A==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.8.0.tgz",
+      "integrity": "sha512-zCz/NzsNRQ1TIfiR3rQNxjeRvgRHEkNdo0FjHQZ6Ay6n4tdCmMrM7+81ThNaf21JLQ1gS2AUG2t5uikGV78obA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "array-tree-filter": "^2.1.0",
         "classnames": "^2.3.1",
-        "rc-select": "~14.1.0",
+        "rc-select": "~14.2.0",
         "rc-tree": "~5.7.0",
         "rc-util": "^5.6.1"
       }
@@ -12035,11 +12211,12 @@
       }
     },
     "rc-input-number": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.3.11.tgz",
-      "integrity": "sha512-aMWPEjFeles6PQnMqP5eWpxzsvHm9rh1jQOWXExUEIxhX62Fyl/ptifLHOn17+waDG1T/YUb6flfJbvwRhHrbA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.4.0.tgz",
+      "integrity": "sha512-r/Oub/sPYbzqLNUOHnnc9sbCu78a81KX+RCbRwmpvB4W6nptUySbdWS5KHV4Hak5CAE1LAd+wWm5JjvZizG1FA==",
       "requires": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/mini-decimal": "^1.0.1",
         "classnames": "^2.2.5",
         "rc-util": "^5.23.0"
       }
@@ -12058,17 +12235,16 @@
       }
     },
     "rc-menu": {
-      "version": "9.8.1",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.8.1.tgz",
-      "integrity": "sha512-179weouypfjWJSRvvoo/vPy+StojsMzK2XC5jRNhL1ryt/N/8wAFESte8K6jZJkNp9DHDLFTe+dCGmikKpiFuA==",
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.8.2.tgz",
+      "integrity": "sha512-EahOJVjLuEnJsThoPN+mGnVm431RzVzDLZWHRS/YnXTQULa7OsgdJa/Y7qXxc3Z5sz8mgT6xYtgpmBXLxrZFaQ==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
         "rc-motion": "^2.4.3",
         "rc-overflow": "^1.2.8",
         "rc-trigger": "^5.1.2",
-        "rc-util": "^5.12.0",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.27.0"
       }
     },
     "rc-motion": {
@@ -12082,13 +12258,13 @@
       }
     },
     "rc-notification": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-4.6.0.tgz",
-      "integrity": "sha512-xF3MKgIoynzjQAO4lqsoraiFo3UXNYlBfpHs0VWvwF+4pimen9/H1DYLN2mfRWhHovW6gRpla73m2nmyIqAMZQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.0.2.tgz",
+      "integrity": "sha512-74wUFiLlyr6lRGEY1m1BaTiDp+0lIT4FRAblMnh9FApyK2JGdsSLbrQ/1rgM7d2N/IX5UIr8kLLW3TdXxFt/jQ==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "rc-motion": "^2.2.0",
+        "rc-motion": "^2.6.0",
         "rc-util": "^5.20.1"
       }
     },
@@ -12113,18 +12289,14 @@
       }
     },
     "rc-picker": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-2.7.0.tgz",
-      "integrity": "sha512-oZH6FZ3j4iuBxHB4NvQ6ABRsS2If/Kpty1YFFsji7/aej6ruGmfM7WnJWQ88AoPfpJ++ya5z+nVEA8yCRYGKyw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-3.1.5.tgz",
+      "integrity": "sha512-Hh3ml+u+5mxLfl4ahVWlRGiX5+0EJrALR6tSW9yP0eea+6j+YjvjfetbvuVidViMDMweZa38dr8HTfAFLG6GFw==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
-        "date-fns": "2.x",
-        "dayjs": "1.x",
-        "moment": "^2.24.0",
         "rc-trigger": "^5.0.4",
-        "rc-util": "^5.4.0",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.27.0"
       }
     },
     "rc-progress": {
@@ -12170,9 +12342,9 @@
       }
     },
     "rc-select": {
-      "version": "14.1.16",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.1.16.tgz",
-      "integrity": "sha512-71XLHleuZmufpdV2vis5oituRkhg2WNvLpVMJBGWRar6WGAVOHXaY9DR5HvwWry3EGTn19BqnL6Xbybje6f8YA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.2.0.tgz",
+      "integrity": "sha512-tvxHmbAA0EIhBkB7dyaRhcBUIWHocQbUFY/fBlezj2jg5p65a5VQ/UhBg2I9TA1wjpsr5CCx0ruZPkYcUMjDoQ==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -12180,7 +12352,7 @@
         "rc-overflow": "^1.0.0",
         "rc-trigger": "^5.0.4",
         "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.2.0"
+        "rc-virtual-list": "^3.4.13"
       }
     },
     "rc-slider": {
@@ -12195,9 +12367,9 @@
       }
     },
     "rc-steps": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-5.0.0.tgz",
-      "integrity": "sha512-9TgRvnVYirdhbV0C3syJFj9EhCRqoJAsxt4i1rED5o8/ZcSv5TLIYyo4H8MCjLPvbe2R+oBAm/IYBEtC+OS1Rw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-6.0.0.tgz",
+      "integrity": "sha512-+KfMZIty40mYCQSDvYbZ1jwnuObLauTiIskT1hL4FFOBHP6ZOr8LK0m143yD3kEN5XKHSEX1DIwCj3AYZpoeNQ==",
       "requires": {
         "@babel/runtime": "^7.16.7",
         "classnames": "^2.2.3",
@@ -12205,9 +12377,9 @@
       }
     },
     "rc-switch": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-3.2.2.tgz",
-      "integrity": "sha512-+gUJClsZZzvAHGy1vZfnwySxj+MjLlGRyXKXScrtCTcmiYNPzxDFOxdQ/3pK1Kt/0POvwJ/6ALOR8gwdXGhs+A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-4.0.0.tgz",
+      "integrity": "sha512-IfrYC99vN0gKaTyjQdqYuADU0eH00SAFHg3jOp8HrmUpJruhV1SohJzrCbPqPraZeX/6X/QKkdLfkdnUub05WA==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
@@ -12215,15 +12387,15 @@
       }
     },
     "rc-table": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.26.0.tgz",
-      "integrity": "sha512-0cD8e6S+DTGAt5nBZQIPFYEaIukn17sfa5uFL98faHlH/whZzD8ii3dbFL4wmUDEL4BLybhYop+QUfZJ4CPvNQ==",
+      "version": "7.30.3",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.30.3.tgz",
+      "integrity": "sha512-PHe+lZKwPo3qui5j79m54vKu8b4hebk04x+4Hy65NvwUU3+NNFGS5FZpylXQMkueMnE8hgh22ZuScQDkCtzQFQ==",
       "requires": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/context": "^1.3.0",
         "classnames": "^2.2.5",
         "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.22.5",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.27.1"
       }
     },
     "rc-tabs": {
@@ -12275,21 +12447,21 @@
       }
     },
     "rc-tree-select": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.5.5.tgz",
-      "integrity": "sha512-k2av7jF6tW9bIO4mQhaVdV4kJ1c54oxV3/hHVU+oD251Gb5JN+m1RbJFTMf1o0rAFqkvto33rxMdpafaGKQRJw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.6.0.tgz",
+      "integrity": "sha512-XG6pu0a9l6+mzhQqUYfR2VIONbe/3LjVc3wKt28k6uBMZsI1j+SSxRyt/7jWRq8Kok8jHJBQASlDg6ehr9Sp0w==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "rc-select": "~14.1.0",
+        "rc-select": "~14.2.0",
         "rc-tree": "~5.7.0",
         "rc-util": "^5.16.1"
       }
     },
     "rc-trigger": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.3.1.tgz",
-      "integrity": "sha512-5gaFbDkYSefZ14j2AdzucXzlWgU2ri5uEjkHvsf1ynRhdJbKxNOnw4PBZ9+FVULNGFiDzzlVF8RJnR9P/xrnKQ==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.3.4.tgz",
+      "integrity": "sha512-mQv+vas0TwKcjAO2izNPkqR4j86OemLRmvL2nOzdP9OWNWA1ivoTt5hzFqYNW9zACwmTezRiN8bttrC7cZzYSw==",
       "requires": {
         "@babel/runtime": "^7.18.3",
         "classnames": "^2.2.6",
@@ -12673,11 +12845,11 @@
       }
     },
     "scroll-into-view-if-needed": {
-      "version": "2.2.29",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.29.tgz",
-      "integrity": "sha512-hxpAR6AN+Gh53AdAimHM6C8oTN1ppwVZITihix+WqalywBeFcQ6LdQP5ABNl26nX8GTEL7VT+b8lKpdqq65wXg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.0.4.tgz",
+      "integrity": "sha512-s+/F50jwTOUt+u5oEIAzum9MN2lUQNvWBe/zfEsVQcbaERjGkKLq1s+2wCHkahMLC8nMLbzMVKivx9JhunXaZg==",
       "requires": {
-        "compute-scroll-into-view": "^1.0.17"
+        "compute-scroll-into-view": "^2.0.4"
       }
     },
     "semver": {
@@ -13305,6 +13477,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "throttle-debounce": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+      "integrity": "sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg=="
     },
     "tiny-invariant": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@emotion/styled": "^11.10.5",
     "@mui/material": "^5.11.6",
     "@types/react-big-calendar": "^0.38.1",
-    "antd": "^4.22.1",
+    "antd": "^5.1.0",
     "emailjs": "^4.0.0",
     "emailjs-com": "^3.2.0",
     "html2canvas": "^1.4.1",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -93,9 +93,9 @@ export default function Home({ events, filters }) {
 
   return (
     <Layout isHome>
-      <div className="Home">
+      <div>
         <Head>
-          <title>Home | Calendarium</title>
+          <title>Events | Calendarium</title>
           <meta name="Calendarium" content="Calendar of events and exams" />
           <link rel="icon" href="/favicon-calendarium.ico" />
         </Head>
@@ -135,6 +135,7 @@ export default function Home({ events, filters }) {
           <EventModal
             selectedEvent={selectedEvent}
             setInspectEvent={setInspectEvent}
+            inspectEvent={inspectEvent}
           />
         )}
 

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -9,7 +9,7 @@ import FeedbackForm from "../components/FeedbackForm";
 import EventModalShift from "../components/EventModalShift";
 
 import Layout from "../components/Layout";
-import { SelectSchedule } from "../components/SelectSchedule";
+import SelectSchedule from "../components/SelectSchedule";
 
 import { IFilterDTO, IShiftDTO } from "../dtos";
 

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -171,6 +171,7 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
           <EventModalShift
             selectedShift={selectedShift}
             setInspectShift={setInspectShift}
+            inspectShift={inspectShift}
           />
         )}
 

--- a/styles/schedule.module.css
+++ b/styles/schedule.module.css
@@ -1,4 +1,5 @@
 .filters {
+  width: 100%;
   margin: 0 0 1rem 0;
 }
 
@@ -8,7 +9,7 @@
   padding-top: 4.9rem;
 }
 
-@media (max-width: 881px) {
+@media (max-width: 1070px) {
   .schedule {
     padding-top: 0;
   }


### PR DESCRIPTION
Added a `Clear Schedule` button that allows the user to easily clean all he's Schedule selections. This was also a feature suggested by users and it's useful for changing schedules when a new semester begins or to play around with possible schedules.

Other  improvements:
- Turn `SelectSchedule` into a component with a scss module

**Preview:**

![image](https://user-images.githubusercontent.com/80540164/217269383-0e8a3d14-da09-4ad3-88f6-6f6d5d3556e4.png)

![image](https://user-images.githubusercontent.com/80540164/217269100-6e8e1556-5320-4643-ad21-b44979084b28.png)