### PR TITLE
Add 2y2s events & Improve shift view

### DIFF
--- a/components/EventModalShift/EventModalShift.tsx
+++ b/components/EventModalShift/EventModalShift.tsx
@@ -1,5 +1,4 @@
 import { Modal, Box, Typography, Grow } from "@mui/material";
-import { useState } from "react";
 
 function EventModalShift({
   selectedShift: {
@@ -16,6 +15,7 @@ function EventModalShift({
   },
   setInspectShift,
   inspectShift,
+  shifts,
 }) {
   const start_hour = new Date(start).toLocaleTimeString("pt", {
     hour: "numeric",
@@ -30,8 +30,6 @@ function EventModalShift({
   const handleModalClose = () => {
     setInspectShift(false);
   };
-
-  const substrings = title.split("-");
 
   const style = {
     position: "absolute",
@@ -48,6 +46,8 @@ function EventModalShift({
   const ano = String(filterId)[0];
   const semestre = String(filterId)[1];
 
+  const name = shifts.find((shift) => shift.id === id).title;
+
   return (
     <div>
       <Modal open={inspectShift} onClose={handleModalClose}>
@@ -62,7 +62,7 @@ function EventModalShift({
                 borderBottom: "solid rgba(200,200,200,.5) 1px",
               }}
             >
-              {substrings[0]}
+              {name}
             </Typography>
             <Typography id="modal-modal-description" sx={{ mt: 2 }}>
               {ano != "0" && ano != "6" ? (

--- a/data/events.json
+++ b/data/events.json
@@ -552,5 +552,110 @@
     "end": "2023-02-17 18:00",
     "groupId": 7,
     "filterId": 2
+  },
+  {
+    "title": "[BD] 'Checkpoint'",
+    "start": "2023-03-27 00:00",
+    "end": "2023-03-31 23:59",
+    "groupId": 2,
+    "filterId": 221
+  },
+  {
+    "title": "[BD] Teste",
+    "start": "2023-06-02 00:00",
+    "end": "2023-06-02 23:59",
+    "groupId": 2,
+    "filterId": 221
+  },
+  {
+    "title": "[BD] Apresentação TP",
+    "start": "2023-06-05 00:00",
+    "end": "2023-06-09 23:59",
+    "groupId": 2,
+    "filterId": 221
+  },
+  {
+    "title": "[BD] Recurso",
+    "start": "2023-06-23 00:00",
+    "end": "2023-06-23 23:59",
+    "groupId": 2,
+    "filterId": 221
+  },
+  {
+    "title": "[IO] Entrega TP",
+    "start": "2023-03-25 00:00",
+    "end": "2023-03-25 23:59",
+    "groupId": 2,
+    "filterId": 222
+  },
+  {
+    "title": "[IO] Entrega TP",
+    "start": "2023-05-06 00:00",
+    "end": "2023-05-06 23:59",
+    "groupId": 2,
+    "filterId": 222
+  },
+  {
+    "title": "[IO] Teste",
+    "start": "2023-05-24 00:00",
+    "end": "2023-05-24 23:59",
+    "groupId": 2,
+    "filterId": 222
+  },
+  {
+    "title": "[IO] Recurso",
+    "start": "2023-06-14 00:00",
+    "end": "2023-06-14 23:59",
+    "groupId": 2,
+    "filterId": 222
+  },
+  {
+    "title": "[MNOnL] Teste",
+    "start": "2023-05-22 00:00",
+    "end": "2023-05-22 23:59",
+    "groupId": 2,
+    "filterId": 223
+  },
+  {
+    "title": "[POO] Entrega TP",
+    "start": "2023-05-11 00:00",
+    "end": "2023-05-11 23:59",
+    "groupId": 2,
+    "filterId": 224
+  },
+  {
+    "title": "[POO] Teste",
+    "start": "2023-05-31 00:00",
+    "end": "2023-05-31 23:59",
+    "groupId": 2,
+    "filterId": 224
+  },
+  {
+    "title": "[POO] Recurso",
+    "start": "2023-06-21 00:00",
+    "end": "2023-06-21 23:59",
+    "groupId": 2,
+    "filterId": 224
+  },
+  {
+    "title": "[SO] Entrega TP",
+    "start": "2023-05-13 00:00",
+    "end": "2023-05-13 23:59",
+    "groupId": 2,
+    "filterId": 226
+  },
+  {
+    "title": "[SO] Teste",
+    "start": "2023-05-29 00:00",
+    "end": "2023-05-29 23:59",
+    "groupId": 2,
+    "filterId": 226
+  },
+  {
+    "title": "[SO] Recurso",
+    "start": "2023-06-19 00:00",
+    "end": "2023-06-19 23:59",
+    "groupId": 2,
+    "filterId": 226
   }
 ]

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -86,10 +86,11 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
     const formatedEvents = filteredShifts.map((shift) => {
       const [startHour, startMinute] = shift.start.split(":");
       const [endHour, endMinute] = shift.end.split(":");
+      const filter = filters.find((filter) => filter.id === shift.filterId);
 
       return {
         ...shift,
-        title: `${shift.title} - ${shift.shift} I ${
+        title: `${filter.name} - ${shift.shift} I ${
           shift.building.includes("CP") ? "" : "Ed."
         } ${shift.building} - ${shift.room}`,
         start: moment()
@@ -172,6 +173,7 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
             selectedShift={selectedShift}
             setInspectShift={setInspectShift}
             inspectShift={inspectShift}
+            shifts={shifts}
           />
         )}
 


### PR DESCRIPTION
Added all the events known so far for 2nd year 2nd semester and made some improvements to the shift view on Schedule page.
Now the shift title will be composed of the class acronym and the full class title will only be shown on the Modal.

- Add 2year 2sem events
- Improve Schedule view
