### PR TITLE
Fix Timezone Bug

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,8 +32,6 @@ export default function Home({ events, filters }) {
 
   Refer to https://github.com/cesium/calendarium/pull/39
   */
-  moment.tz.setDefault("Africa/Bamako");
-
   const configureDates = (event) => {
     event.start = new Date(event.start);
     event.end = new Date(event.end);


### PR DESCRIPTION
Fixed timezone bug where day light savings were affecting event dates, showing an event say from 26/03/2023 as it being from 26 to 27. Fixed it by simply not setting the timezone on the code, which means it will assume de timezone of the computer the calendar is being view from. This solves all timezone problems for everyone seeing the website from Portugal, or with Portugal's timezone configured anyway. Since the amount of students that will be seeing this from another country or with a f'ed up timezone setting is very low, I think it's good enough for now.
