### PR TITLE
Bug Fix in Filters :rotating_light: 

### DIFF
--- a/components/EventFilters/EventFilters.tsx
+++ b/components/EventFilters/EventFilters.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Checkbox, Collapse } from "antd";
 import "antd/dist/reset.css";
 import styles from "./eventfilters.module.scss";
-import { CaretRightOutlined } from "@ant-design/icons";
 
 const { Panel } = Collapse;
 
@@ -33,7 +32,7 @@ function EventFilters({ filters, handleFilters }) {
 
   const sync = [0, 6];
 
-  const event_index = (index: number, index1: number, index2) => {
+  const event_index = (index: number, index1: number, index2: number) => {
     return sync[index] + index1 * 2 + index2;
   };
 
@@ -110,7 +109,7 @@ function EventFilters({ filters, handleFilters }) {
 
       <Collapse className={styles.checkbox} bordered={false} accordion>
         {lei.map((b, index1) => (
-          <Panel header={b} key={index1 + Math.random()}>
+          <Panel header={b} key={index1}>
             <Collapse
               className={styles.sub_checkbox}
               bordered={false}
@@ -119,8 +118,8 @@ function EventFilters({ filters, handleFilters }) {
               {semesters.map((s, index2) => (
                 <>
                   <CheckedIndicator index={event_index(0, index1, index2)} />
-                  <Panel header={s} key={index2 + Math.random()}>
-                    <React.Fragment key={-1}>
+                  <Panel header={s} key={10 + index1 * 100 + index2}>
+                    <React.Fragment key={100 + index1 * 100 + index2 * 50}>
                       <div
                         style={{
                           padding: "0 0 5px 0",
@@ -141,6 +140,7 @@ function EventFilters({ filters, handleFilters }) {
                             !isAllChecked(event_index(0, index1, index2)) &&
                             !isNoneChecked(event_index(0, index1, index2))
                           }
+                          key={(100 + index1 * 100 + index2 * 50) * 1000}
                         >
                           Select All
                         </Checkbox>
@@ -157,7 +157,9 @@ function EventFilters({ filters, handleFilters }) {
                           },
                           index3: number
                         ) => (
-                          <React.Fragment key={index3 + Math.random()}>
+                          <React.Fragment
+                            key={100 + index1 * 100 + index2 * 50 + index3 + 1}
+                          >
                             <div>
                               <Checkbox
                                 onChange={() => handleToggle(value.id)}
@@ -166,6 +168,14 @@ function EventFilters({ filters, handleFilters }) {
                                   Checked.indexOf(value.id) === -1
                                     ? false
                                     : true
+                                }
+                                key={
+                                  (100 +
+                                    index1 * 100 +
+                                    index2 * 50 +
+                                    index3 +
+                                    1) *
+                                  1000
                                 }
                               >
                                 {value.name}
@@ -188,13 +198,13 @@ function EventFilters({ filters, handleFilters }) {
       {/* 4º ano */}
 
       <Collapse className={styles.checkbox} bordered={false} accordion>
-        <Panel header={mei[0]} key={Math.random()}>
+        <Panel header={mei[0]} key={2625273}>
           <Collapse className={styles.sub_checkbox} bordered={false} accordion>
             {semesters.map((s, index2) => (
               <>
                 <CheckedIndicator index={event_index(1, 0, index2)} />
-                <Panel header={s} key={index2 + Math.random()}>
-                  <React.Fragment key={index2 + 1 + Math.random()}>
+                <Panel header={s} key={10 + index2}>
+                  <React.Fragment key={100 + index2 * 50}>
                     <div
                       style={{
                         padding: "0 0 5px 0",
@@ -231,7 +241,7 @@ function EventFilters({ filters, handleFilters }) {
                         },
                         index3: number
                       ) => (
-                        <React.Fragment key={index3 + Math.random()}>
+                        <React.Fragment key={100 + index2 * 50 + index3 + 1}>
                           <div>
                             <Checkbox
                               onChange={() => handleToggle(value.id)}
@@ -239,6 +249,7 @@ function EventFilters({ filters, handleFilters }) {
                               checked={
                                 Checked.indexOf(value.id) === -1 ? false : true
                               }
+                              key={(100 + index2 * 50 + index3 + 1) * 1000}
                             >
                               {value.name}
                             </Checkbox>
@@ -256,8 +267,8 @@ function EventFilters({ filters, handleFilters }) {
         {/* 5º ano */}
 
         <>
-          <CheckedIndicator index={8} />
-          <Panel header={mei[1]} key={Math.random()}>
+          <CheckedIndicator index={1} />
+          <Panel header={mei[1]} key={23141251}>
             <div style={{ fontWeight: 400 }}>
               {event[8]?.map(
                 (
@@ -269,7 +280,7 @@ function EventFilters({ filters, handleFilters }) {
                   },
                   index: number
                 ) => (
-                  <React.Fragment key={index + Math.random()}>
+                  <React.Fragment key={100 + 100 + index}>
                     <div>
                       <Checkbox
                         onChange={() => handleToggle(value.id)}
@@ -277,6 +288,7 @@ function EventFilters({ filters, handleFilters }) {
                         checked={
                           Checked.indexOf(value.id) === -1 ? false : true
                         }
+                        key={(100 + 100 + index) * 1000}
                       >
                         {value.name}
                       </Checkbox>
@@ -292,8 +304,8 @@ function EventFilters({ filters, handleFilters }) {
       {/* Others */}
 
       <Collapse className={styles.checkbox} bordered={false}>
-        <CheckedIndicator index={9} />
-        <Panel header="Others" key={Math.random()}>
+        <CheckedIndicator index={0} />
+        <Panel header="Others" key={2314134}>
           <div style={{ fontWeight: 400 }}>
             {event[9]?.map(
               (
@@ -305,7 +317,7 @@ function EventFilters({ filters, handleFilters }) {
                 },
                 index: number
               ) => (
-                <React.Fragment key={index + Math.random()}>
+                <React.Fragment key={100 + index}>
                   <div>
                     <Checkbox
                       onChange={() => handleToggle(value.id)}

--- a/components/EventFilters/EventFilters.tsx
+++ b/components/EventFilters/EventFilters.tsx
@@ -140,7 +140,6 @@ function EventFilters({ filters, handleFilters }) {
                             !isAllChecked(event_index(0, index1, index2)) &&
                             !isNoneChecked(event_index(0, index1, index2))
                           }
-                          key={(100 + index1 * 100 + index2 * 50) * 1000}
                         >
                           Select All
                         </Checkbox>
@@ -169,14 +168,6 @@ function EventFilters({ filters, handleFilters }) {
                                     ? false
                                     : true
                                 }
-                                key={
-                                  (100 +
-                                    index1 * 100 +
-                                    index2 * 50 +
-                                    index3 +
-                                    1) *
-                                  1000
-                                }
                               >
                                 {value.name}
                               </Checkbox>
@@ -198,7 +189,7 @@ function EventFilters({ filters, handleFilters }) {
       {/* 4º ano */}
 
       <Collapse className={styles.checkbox} bordered={false} accordion>
-        <Panel header={mei[0]} key={2625273}>
+        <Panel header={mei[0]} key="4">
           <Collapse className={styles.sub_checkbox} bordered={false} accordion>
             {semesters.map((s, index2) => (
               <>
@@ -249,7 +240,6 @@ function EventFilters({ filters, handleFilters }) {
                               checked={
                                 Checked.indexOf(value.id) === -1 ? false : true
                               }
-                              key={(100 + index2 * 50 + index3 + 1) * 1000}
                             >
                               {value.name}
                             </Checkbox>
@@ -268,7 +258,7 @@ function EventFilters({ filters, handleFilters }) {
 
         <>
           <CheckedIndicator index={1} />
-          <Panel header={mei[1]} key={23141251}>
+          <Panel header={mei[1]} key="5">
             <div style={{ fontWeight: 400 }}>
               {event[8]?.map(
                 (
@@ -288,7 +278,6 @@ function EventFilters({ filters, handleFilters }) {
                         checked={
                           Checked.indexOf(value.id) === -1 ? false : true
                         }
-                        key={(100 + 100 + index) * 1000}
                       >
                         {value.name}
                       </Checkbox>
@@ -305,7 +294,7 @@ function EventFilters({ filters, handleFilters }) {
 
       <Collapse className={styles.checkbox} bordered={false}>
         <CheckedIndicator index={0} />
-        <Panel header="Others" key={2314134}>
+        <Panel header="Others" key="Others">
           <div style={{ fontWeight: 400 }}>
             {event[9]?.map(
               (

--- a/components/ScheduleFilters/ScheduleFilters.tsx
+++ b/components/ScheduleFilters/ScheduleFilters.tsx
@@ -161,14 +161,14 @@ const ScheduleFilters = ({ filters, handleFilters }: ISelectScheduleProps) => {
 
       <Collapse className={styles.checkbox} bordered={false} accordion>
         {lei.map((y, index1) => (
-          <Panel header={y} key={index1 + Math.random()}>
+          <Panel header={y} key={index1}>
             <Collapse
               className={styles.sub_checkbox}
               bordered={false}
               accordion
             >
               {semesters.map((s, index2) => (
-                <Panel header={s} key={index2 + Math.random()}>
+                <Panel header={s} key={10 + index1 * 100 + index2}>
                   <Collapse
                     className={styles.sub_sub_sub_checkbox}
                     bordered={false}
@@ -215,14 +215,14 @@ const ScheduleFilters = ({ filters, handleFilters }: ISelectScheduleProps) => {
 
       <Collapse className={styles.checkbox} bordered={false} accordion>
         {mei.map((y, index1) => (
-          <Panel header={y} key={index1 + Math.random()}>
+          <Panel header={y} key={index1 + 1000}>
             <Collapse
               className={styles.sub_sub_checkbox}
               bordered={false}
               accordion
             >
               {semesters.map((s, index2) => (
-                <Panel header={s} key={index2 + Math.random()}>
+                <Panel header={s} key={1000 + 10 + index1 * 100 + index2}>
                   <Collapse
                     className={styles.sub_sub_sub_checkbox}
                     bordered={false}
@@ -299,7 +299,7 @@ const ScheduleFilters = ({ filters, handleFilters }: ISelectScheduleProps) => {
         {others.map((filter) => (
           <CheckedIndicator filter={filter} key={filter.id} />
         ))}
-        <Panel header="Others" key={Math.random()}>
+        <Panel header="Others" key={"Others"}>
           {others.map(
             (filter, index) =>
               !filter.shifts?.length && (


### PR DESCRIPTION
Fixed a bug in the Event and Schedule filters where selecting a checkbox would force the Collapse element to "collapse" immediatly. This for some reason happens when using a random generator for the key values, I was using a random generator to make sure the keys of all elements were always unique. The fix was to just not use a random generator and actually think of a mathematical way to keep the keys different between elements.
