### PR TITLE
fix: events display neutral color

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -122,15 +122,22 @@ export default function Home({ events, filters }) {
   }
 
   function saveTheme() {
-    const theme = localStorage.getItem("theme");
+    let theme = localStorage.getItem("theme");
     const colors = localStorage.getItem("colors");
     const opacity = localStorage.getItem("opacity");
     const customType = localStorage.getItem("customType") ?? "Year";
     const subjectColors: SubjectColor[] =
       JSON.parse(localStorage.getItem("subjectColors")) ?? [];
 
-    theme && setTheme(theme);
+    !theme && localStorage.setItem("theme", "Modern");
+    !customType && localStorage.setItem("customType", "Subject");
 
+    if (theme !== "Modern" && theme !== "Classic" && theme !== "Custom") {
+      localStorage.setItem("theme", "Modern");
+      theme = "Modern";
+    }
+
+    setTheme(theme);
     if (theme === "Custom") {
       setCustomType(customType);
 

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -114,16 +114,22 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
   }
 
   function saveTheme() {
-    const theme = localStorage.getItem("theme");
+    let theme = localStorage.getItem("theme");
     const colors = localStorage.getItem("colors");
     const opacity = localStorage.getItem("opacity");
     const customType = localStorage.getItem("customType");
     const subjectColors: SubjectColor[] =
       JSON.parse(localStorage.getItem("subjectColors")) ?? [];
 
-    theme && setTheme(theme);
+    !theme && localStorage.setItem("theme", "Modern");
     !customType && localStorage.setItem("customType", "Subject");
 
+    if (theme !== "Modern" && theme !== "Classic" && theme !== "Custom") {
+      localStorage.setItem("theme", "Modern");
+      theme = "Modern";
+    }
+
+    setTheme(theme);
     if (theme === "Custom") {
       setCustomType(customType);
 


### PR DESCRIPTION
Fixed a bug whose origin is still unknown that causes the "theme" parameter in local storage to be set to "null" causing the event colors to display a neutral black color. Fixed this in two ways:

1. Check if the "theme" parameter exists and set it to "Modern" by default;
2. If the "theme" parameter exists, check if it falls under "Modern", "Classic" or "Custom" and set it to the default ("Modern") if it doesn't.
