### PR TITLE
feat: dynamic modal width

### DIFF
--- a/components/EventModal/EventModal.tsx
+++ b/components/EventModal/EventModal.tsx
@@ -41,7 +41,7 @@ function EventModal({
         slotProps={{ backdrop: { timeout: 300 } }}
       >
         <Fade in={inspectEvent}>
-          <Box className="absolute left-1/2 top-1/2 h-fit w-72 -translate-x-1/2 -translate-y-1/2 transform rounded-3xl border bg-white p-6 text-center shadow-xl">
+          <Box className="absolute left-1/2 top-1/2 h-fit w-fit min-w-[18rem] -translate-x-1/2 -translate-y-1/2 transform rounded-3xl border bg-white p-6 text-center shadow-xl">
             <Typography
               id="modal-modal-title"
               className="border-b pb-3"

--- a/components/ShiftModal/ShiftModal.tsx
+++ b/components/ShiftModal/ShiftModal.tsx
@@ -44,7 +44,7 @@ function ShiftModal({
         slotProps={{ backdrop: { timeout: 300 } }}
       >
         <Fade in={inspectShift}>
-          <Box className="absolute left-1/2 top-1/2 h-fit w-72 -translate-x-1/2 -translate-y-1/2 transform rounded-3xl border bg-white p-6 text-center shadow-xl">
+          <Box className="absolute left-1/2 top-1/2 h-fit w-fit min-w-[18rem] -translate-x-1/2 -translate-y-1/2 transform rounded-3xl border bg-white p-6 text-center shadow-xl">
             <Typography
               id="modal-modal-title"
               className="border-b pb-3"


### PR DESCRIPTION
Made it so the `EventModal` and `ShiftModal` have a dynamic width, instead of a fixed one. The modal will have a minimum width of 18rem (same as previously) and only expand to a `w-fit` if it's needed. This is particularly useful on `EventModal`, since it can house a link with unpredictable size. A great example is the current Code Week event, where the link is wrapping down because of the fixed width.