### PR TITLE
feat: add trello integration action

### DIFF
--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -11,14 +11,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Create a Trello Card
-        uses: TrisNol/trello-create-card-action@v0.0.5
-        with:
-          api_key: ${{ secrets.TRELLO_API_KEY }}
-          token: ${{ secrets.TRELLO_API_TOKEN }}
-          list_id: 654d17b1769ab53537f652f7
-          card_name: ${{ github.event.pull_request.title }}
-
       - name: Link to Trello
         uses: rematocorp/trello-integration-action@v7.1.0
         with:

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -65,7 +65,7 @@ jobs:
           trello-add-labels-to-cards: true
 
           # When a card has one of these labels then branch category label is not assigned.
-          trello-conflicting-labels: "feature;bug;chore;calendarium;hydrogen;atomic;shuriken;bokken;seium;safira"
+          trello-conflicting-labels: ""
 
           # When set to true, search for card also within the branch name (e.g. "1234-card-title").
           # If card id is found, comments card URL.

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -11,6 +11,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # The steps bellow are necessary to trigger issue_comment correctly
+      - name: Get PR branch
+        uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+        
+      - name: Checkout PR branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          
+      # Link PR to Trello    
       - name: Link to Trello
         uses: rematocorp/trello-integration-action@v7.1.0
         with:

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -41,7 +41,7 @@ jobs:
 
           # Your organization name to avoid assigning cards to outside members,
           # edit your workspace details and look for the short name.
-          trello-organization-name: CeSIUM - 23/24
+          trello-organization-name: cesium2324
 
           # Trello board ID where to move the cards.
           # How to find board ID: https://stackoverflow.com/a/50908600/2311110

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -1,79 +1,21 @@
-name: Trello Integration
+name: Issue Into Trello Card
+
 on:
-  pull_request:
-    types:
-      [opened, edited, closed, reopened, ready_for_review, converted_to_draft, assigned]
-  issue_comment:
-    types: [created, edited]
+  issues:
+    types: [opened, reopened]
+
 jobs:
-  build:
+  create_trello_card_job:
     runs-on: ubuntu-latest
+    name: Create Trello Card
     steps:
-      - uses: rematocorp/trello-integration-action@v7.1.0
-        with:
-          # REQUIRED
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-          # When set to true, match only URLs prefixed with “Closes” etc.
-          # Just like https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-          # Default: false
-          github-require-keyword-prefix: false
-
-          # Throw an error if no Trello cards can be found in the PR description.
-          # Default: false
-          github-require-trello-card: false
-
-          # Newline-separated list of mapping between Github username and Trello username.
-          # Use it for people who have different usernames in Github and Trello.
-          # If the current username is not in the list, we still try to find a Trello user with that username.
-          github-users-to-trello-users: |-
-            GithubUser1:TrelloUser1
-            GithubUser2:TrelloUser2
-
-          # REQUIRED: Trello API key, visit https://trello.com/app-key for key.
-          trello-api-key: ${{ secrets.TRELLO_API_KEY }}
-
-          # REQUIRED: Trello auth token, visit https://trello.com/app-key then click generate a token.
-          trello-auth-token: ${{ secrets.TRELLO_API_TOKEN }}
-
-          # Your organization name to avoid assigning cards to outside members,
-          # edit your workspace details and look for the short name.
-          trello-organization-name: CeSIUM - 23/24
-
-          # Trello board ID where to move the cards.
-          # How to find board ID: https://stackoverflow.com/a/50908600/2311110
-          trello-board-id: 64c01c6ddfe475d0a4ee2f2a
-
-          # Trello list ID for draft pull request.
-          # Useful when you want to move the card back to In progress when ready PR is converted to draft.
-          # How to find list ID: https://stackoverflow.com/a/50908600/2311110
-          trello-list-id-pr-draft: 654d17b1769ab53537f652f7
-
-          # Trello list ID for open pull request.
-          # How to find list ID: https://stackoverflow.com/a/50908600/2311110
-          trello-list-id-pr-open: 654d1801fe9fdff5e4ad442b
-
-          # Trello list ID for closed pull request.
-          # How to find list ID: https://stackoverflow.com/a/50908600/2311110
-          trello-list-id-pr-closed: 654d17cc0ddb0bf601d881a0
-
-          # Enable or disable the automatic addition of labels to cards.
-          # Default: true
-          trello-add-labels-to-cards: true
-
-          # When a card has one of these labels then branch category label is not assigned.
-          trello-conflicting-labels: "calendarium;atomic;seium;safira;shuriken;bokken;hydrogen;cesium.link"
-
-          # When set to true, search for card also within the branch name (e.g. "1234-card-title").
-          # If card id is found, comments card URL.
-          # Default: false
-          trello-card-in-branch-name: true
-
-          # Position of the card after being moved to a list.
-          # Options: "top" or "bottom"
-          # Default: "top"
-          trello-card-position: "top"
-
-          # Enable or disable the removal of unrelated users on Trello cards.
-          # Default: true
-          trello-remove-unrelated-members: true
+    - name: Call trello-github-actions
+      id: call-trello-github-actions
+      uses: jessicazu/trello-github-actions@v1.0
+      with:
+        trello-action: create_card_when_issue_opened
+      env:
+        TRELLO_API_KEY: ${{ secrets.TRELLO_API_KEY }}
+        TRELLO_API_TOKEN: ${{ secrets.TRELLO_API_TOKEN }}
+        TRELLO_BOARD_ID: ${{ secrets.TRELLO_BOARD_ID }}
+        TRELLO_LIST_ID: ${{ secrets.TRELLO_TO_DO_LIST_ID }}

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: rematocorp/trello-integration-action@v7
+      - uses: rematocorp/trello-integration-action@v7.1.0
         with:
           # REQUIRED
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -2,9 +2,9 @@ name: Trello Integration
 
 on:
     pull_request:
-        types: [opened, edited, closed, reopened, ready_for_review, converted_to_draft, assigned]
+      types: [opened, synchronize, edited, closed, reopened, ready_for_review, converted_to_draft, assigned]
     issue_comment:
-        types: [created, edited]
+      types: [created, edited]
 
 jobs:
     build:

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -2,7 +2,7 @@ name: Trello Integration
 
 on:
     pull_request:
-        types: [opened, edited, closed, reopened, ready_for_review, converted_to_draft]
+        types: [opened, edited, closed, reopened, ready_for_review, converted_to_draft, assigned]
     issue_comment:
         types: [created, edited]
 

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -1,11 +1,11 @@
 name: Trello Integration
 
 on:
+  issue_comment:
+    types: [created, edited, deleted]
   pull_request:
     types:
       [opened, edited, closed, reopened, ready_for_review, converted_to_draft]
-  issue_comment:
-    types: [created, edited]
 
 jobs:
   build:
@@ -30,8 +30,8 @@ jobs:
           # Use it for people who have different usernames in Github and Trello.
           # If the current username is not in the list, we still try to find a Trello user with that username.
           github-users-to-trello-users: |-
-            GithubUser1:TrelloUser1
-            GithubUser2:TrelloUser2
+            diogogmatos:diogogmatos
+            ruilopesm:ruilopesm
 
           # REQUIRED: Trello API key, visit https://trello.com/app-key for key.
           trello-api-key: ${{ secrets.TRELLO_API_KEY }}

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -34,7 +34,7 @@ jobs:
           trello-api-key: ${{ secrets.TRELLO_API_KEY }}
 
           # REQUIRED: Trello auth token, visit https://trello.com/app-key then click generate a token.
-          trello-auth-token: ${{ secrets.TRELLO_AUTH_TOKEN }}
+          trello-auth-token: ${{ secrets.TRELLO_API_TOKEN }}
 
           # Your organization name to avoid assigning cards to outside members,
           # edit your workspace details and look for the short name.

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -30,8 +30,7 @@ jobs:
           # Use it for people who have different usernames in Github and Trello.
           # If the current username is not in the list, we still try to find a Trello user with that username.
           github-users-to-trello-users: |-
-            diogogmatos:diogogmatos
-            ruilopesm:ruilopesm
+            wtv:wtv
 
           # REQUIRED: Trello API key, visit https://trello.com/app-key for key.
           trello-api-key: ${{ secrets.TRELLO_API_KEY }}

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -1,0 +1,79 @@
+name: Trello Integration
+on:
+  pull_request:
+    types:
+      [opened, edited, closed, reopened, ready_for_review, converted_to_draft]
+  issue_comment:
+    types: [created, edited]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rematocorp/trello-integration-action@v7
+        with:
+          # REQUIRED
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # When set to true, match only URLs prefixed with “Closes” etc.
+          # Just like https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
+          # Default: false
+          github-require-keyword-prefix: false
+
+          # Throw an error if no Trello cards can be found in the PR description.
+          # Default: false
+          github-require-trello-card: false
+
+          # Newline-separated list of mapping between Github username and Trello username.
+          # Use it for people who have different usernames in Github and Trello.
+          # If the current username is not in the list, we still try to find a Trello user with that username.
+          github-users-to-trello-users: |-
+            GithubUser1:TrelloUser1
+            GithubUser2:TrelloUser2
+
+          # REQUIRED: Trello API key, visit https://trello.com/app-key for key.
+          trello-api-key: ${{ secrets.TRELLO_API_KEY }}
+
+          # REQUIRED: Trello auth token, visit https://trello.com/app-key then click generate a token.
+          trello-auth-token: ${{ secrets.TRELLO_AUTH_TOKEN }}
+
+          # Your organization name to avoid assigning cards to outside members,
+          # edit your workspace details and look for the short name.
+          trello-organization-name: CeSIUM - 23/24
+
+          # Trello board ID where to move the cards.
+          # How to find board ID: https://stackoverflow.com/a/50908600/2311110
+          trello-board-id: 64c01c6ddfe475d0a4ee2f2a
+
+          # Trello list ID for draft pull request.
+          # Useful when you want to move the card back to In progress when ready PR is converted to draft.
+          # How to find list ID: https://stackoverflow.com/a/50908600/2311110
+          trello-list-id-pr-draft: 654d17b1769ab53537f652f7
+
+          # Trello list ID for open pull request.
+          # How to find list ID: https://stackoverflow.com/a/50908600/2311110
+          trello-list-id-pr-open: 654d1801fe9fdff5e4ad442b
+
+          # Trello list ID for closed pull request.
+          # How to find list ID: https://stackoverflow.com/a/50908600/2311110
+          trello-list-id-pr-closed: 654d17cc0ddb0bf601d881a0
+
+          # Enable or disable the automatic addition of labels to cards.
+          # Default: true
+          trello-add-labels-to-cards: true
+
+          # When a card has one of these labels then branch category label is not assigned.
+          trello-conflicting-labels: "calendarium;atomic;seium;safira;shuriken;bokken;hydrogen;cesium.link"
+
+          # When set to true, search for card also within the branch name (e.g. "1234-card-title").
+          # If card id is found, comments card URL.
+          # Default: false
+          trello-card-in-branch-name: false
+
+          # Position of the card after being moved to a list.
+          # Options: "top" or "bottom"
+          # Default: "top"
+          trello-card-position: "top"
+
+          # Enable or disable the removal of unrelated users on Trello cards.
+          # Default: true
+          trello-remove-unrelated-members: true

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -1,21 +1,32 @@
-name: Issue Into Trello Card
+name: Trello Integration
 
 on:
-  issues:
-    types: [opened, reopened]
+    pull_request:
+        types: [opened, edited, closed, reopened, ready_for_review, converted_to_draft]
+    issue_comment:
+        types: [created, edited]
 
 jobs:
-  create_trello_card_job:
-    runs-on: ubuntu-latest
-    name: Create Trello Card
-    steps:
-    - name: Call trello-github-actions
-      id: call-trello-github-actions
-      uses: jessicazu/trello-github-actions@v1.0
-      with:
-        trello-action: create_card_when_issue_opened
-      env:
-        TRELLO_API_KEY: ${{ secrets.TRELLO_API_KEY }}
-        TRELLO_API_TOKEN: ${{ secrets.TRELLO_API_TOKEN }}
-        TRELLO_BOARD_ID: ${{ secrets.TRELLO_BOARD_ID }}
-        TRELLO_LIST_ID: ${{ secrets.TRELLO_TO_DO_LIST_ID }}
+    build:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Link to Trello
+            uses: kagof/trello-link-github-action@v1.1.0
+            with:
+              # Required.
+              # Allowed to be one of the following:
+              # 1. the board name
+              # 2. the board shortLink (can be found in the URL)
+              # 3. the boardId (can be found via the Trello REST API)
+              board-identifier: "${{ secrets.TRELLO_BOARD_ID }}"
+              # Required
+              # Secret token used to contact Trello
+              trello-token: "${{ secrets.TRELLO_GH_ACTION_KEY }}"
+              # Optional (default 'TRELLO-')
+              # When preceding a string in a commit message or PR body or title,
+              # indicates that the string is a Trello shortId.
+              # May be either:
+              # 1. an alpha string, eg TRELLO
+              # 2. an alpha string followed by a dash, eg TRELLO-
+              # 3. one of the characters ! @ # $ % ^ & * + = (note: must be exactly 1 char long)
+              marker: 'TRELLO-'

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -67,7 +67,7 @@ jobs:
           # When set to true, search for card also within the branch name (e.g. "1234-card-title").
           # If card id is found, comments card URL.
           # Default: false
-          trello-card-in-branch-name: false
+          trello-card-in-branch-name: true
 
           # Position of the card after being moved to a list.
           # Options: "top" or "bottom"

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -10,17 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    steps:
-      # The steps bellow are necessary to trigger issue_comment correctly
-      - name: Get PR branch
-        uses: xt0rted/pull-request-comment-branch@v2
-        id: comment-branch
-        
-      - name: Checkout PR branch
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
-          
+    steps: 
       # Link PR to Trello    
       - name: Link to Trello
         uses: rematocorp/trello-integration-action@v7.1.0

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -2,7 +2,7 @@ name: Trello Integration
 on:
   pull_request:
     types:
-      [opened, edited, closed, reopened, ready_for_review, converted_to_draft]
+      [opened, edited, closed, reopened, ready_for_review, converted_to_draft, assigned]
   issue_comment:
     types: [created, edited]
 jobs:

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -1,32 +1,82 @@
 name: Trello Integration
 
 on:
-    pull_request:
-      types: [opened, synchronize, edited, closed, reopened, ready_for_review, converted_to_draft, assigned]
-    issue_comment:
-      types: [created, edited]
+  pull_request:
+    types:
+      [opened, edited, closed, reopened, ready_for_review, converted_to_draft]
+  issue_comment:
+    types: [created, edited]
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-          - name: Link to Trello
-            uses: kagof/trello-link-github-action@v1.1.0
-            with:
-              # Required.
-              # Allowed to be one of the following:
-              # 1. the board name
-              # 2. the board shortLink (can be found in the URL)
-              # 3. the boardId (can be found via the Trello REST API)
-              board-identifier: "${{ secrets.TRELLO_BOARD_ID }}"
-              # Required
-              # Secret token used to contact Trello
-              trello-token: "${{ secrets.TRELLO_GH_ACTION_KEY }}"
-              # Optional (default 'TRELLO-')
-              # When preceding a string in a commit message or PR body or title,
-              # indicates that the string is a Trello shortId.
-              # May be either:
-              # 1. an alpha string, eg TRELLO
-              # 2. an alpha string followed by a dash, eg TRELLO-
-              # 3. one of the characters ! @ # $ % ^ & * + = (note: must be exactly 1 char long)
-              marker: 'TRELLO-'
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Link to Trello
+        uses: rematocorp/trello-integration-action@v7.1.0
+        with:
+          # REQUIRED
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # When set to true, match only URLs prefixed with “Closes” etc.
+          # Just like https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
+          # Default: false
+          github-require-keyword-prefix: false
+
+          # Throw an error if no Trello cards can be found in the PR description.
+          # Default: false
+          github-require-trello-card: true
+
+          # Newline-separated list of mapping between Github username and Trello username.
+          # Use it for people who have different usernames in Github and Trello.
+          # If the current username is not in the list, we still try to find a Trello user with that username.
+          github-users-to-trello-users: |-
+            GithubUser1:TrelloUser1
+            GithubUser2:TrelloUser2
+
+          # REQUIRED: Trello API key, visit https://trello.com/app-key for key.
+          trello-api-key: ${{ secrets.TRELLO_API_KEY }}
+
+          # REQUIRED: Trello auth token, visit https://trello.com/app-key then click generate a token.
+          trello-auth-token: ${{ secrets.TRELLO_API_TOKEN }}
+
+          # Your organization name to avoid assigning cards to outside members,
+          # edit your workspace details and look for the short name.
+          trello-organization-name: CeSIUM - 23/24
+
+          # Trello board ID where to move the cards.
+          # How to find board ID: https://stackoverflow.com/a/50908600/2311110
+          trello-board-id: 64c01c6ddfe475d0a4ee2f2a
+
+          # Trello list ID for draft pull request.
+          # Useful when you want to move the card back to In progress when ready PR is converted to draft.
+          # How to find list ID: https://stackoverflow.com/a/50908600/2311110
+          trello-list-id-pr-draft: 654d17b1769ab53537f652f7
+
+          # Trello list ID for open pull request.
+          # How to find list ID: https://stackoverflow.com/a/50908600/2311110
+          trello-list-id-pr-open: 654d1801fe9fdff5e4ad442b
+
+          # Trello list ID for closed pull request.
+          # How to find list ID: https://stackoverflow.com/a/50908600/2311110
+          trello-list-id-pr-closed: 654d17cc0ddb0bf601d881a0
+
+          # Enable or disable the automatic addition of labels to cards.
+          # Default: true
+          trello-add-labels-to-cards: true
+
+          # When a card has one of these labels then branch category label is not assigned.
+          trello-conflicting-labels: "feature;bug;chore;calendarium;hydrogen;atomic;shuriken;bokken;seium;safira"
+
+          # When set to true, search for card also within the branch name (e.g. "1234-card-title").
+          # If card id is found, comments card URL.
+          # Default: false
+          trello-card-in-branch-name: false
+
+          # Position of the card after being moved to a list.
+          # Options: "top" or "bottom"
+          # Default: "top"
+          trello-card-position: "top"
+
+          # Enable or disable the removal of unrelated users on Trello cards.
+          # Default: true
+          trello-remove-unrelated-members: true

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -11,6 +11,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Create a Trello Card
+        uses: TrisNol/trello-create-card-action@v0.0.5
+        with:
+          api_key: ${{ secrets.TRELLO_API_KEY }}
+          token: ${{ secrets.TRELLO_API_TOKEN }}
+          list_id: 654d17b1769ab53537f652f7
+          card_name: ${{ github.event.pull_request.title }}
+
       - name: Link to Trello
         uses: rematocorp/trello-integration-action@v7.1.0
         with:

--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ Check out this example, where we set the above schedule to start on 11/09/2023 a
 https://calendario.cesium.di.uminho.pt/api/export/schedule?CP=T1&CP=TP1&CC=T1&CC=PL1&DSS=T1&DSS=PL1&IA=T1&IA=PL1&LI4=T1&LI4=OT1&SD=T1&SD=PL1&start=2023-09-11&end=2024-08-08
 ```
 
-*Note that you can define **just the start, just the end, both or neither**. The parameter you omit will assume the default behaviour.*
+_Note that you can define **just the start, just the end, both or neither**. The parameter you omit will assume the default behaviour._


### PR DESCRIPTION
This action allows to automatically link a Trello Card with a PR by adding a link to an existing card anywhere in the PR body. Most importantly, it automatically moves the Trello Card to "Doing", "Review" or "Done" if the PR is a draft, is opened or is closed, respectively.

The idea would be to implement this action on all the repositories we currently have on Trello. t