### PR TITLE
fix: bug in event fetching for `groupId = 0`

### DIFF
--- a/components/EventModal/EventModal.tsx
+++ b/components/EventModal/EventModal.tsx
@@ -31,6 +31,15 @@ function EventModal({
     setInspectEvent(false);
   };
 
+  const dateInfo = (
+    <>
+      <i className="bi bi-calendar-fill"></i>{" "}
+      {start_date.localeCompare(end_date)
+        ? `${start_date} - ${end_date}`
+        : `${start_date}`}
+    </>
+  );
+
   return (
     <div>
       <Modal
@@ -56,27 +65,43 @@ function EventModal({
             <Typography id="modal-modal-description" sx={{ mt: 2 }}>
               {/* DATE & TIME */}
               <div>
-                <i className="bi bi-calendar-fill"></i>{" "}
-                {start_date.localeCompare(end_date)
-                  ? `${start_date} - ${end_date}`
-                  : `${start_date}`}
-                {start_hour.localeCompare("00:00") &&
-                !start_date.localeCompare(end_date) ? (
-                  <div>
-                    <p></p>
-                    <i className="bi bi-clock-fill"></i> {start_hour} -{" "}
-                    {end_hour}
-                  </div>
+                {start_hour.localeCompare("00:00") ? (
+                  start_date.localeCompare(end_date) ? (
+                    <div>
+                      <p></p>
+                      <i className="bi bi-clock-fill"></i>{" "}
+                      <text className="font-medium">
+                        {start_date.slice(0, 5)}
+                      </text>
+                      , {start_hour} -{" "}
+                      <text className="font-medium">
+                        {end_date.slice(0, 5)}
+                      </text>
+                      , {end_hour}
+                    </div>
+                  ) : (
+                    <div>
+                      {dateInfo}
+                      <p></p>
+                      <i className="bi bi-clock-fill"></i> {start_hour} -{" "}
+                      {end_hour}
+                    </div>
+                  )
                 ) : (
-                  ""
+                  <>{dateInfo}</>
                 )}
               </div>
               {/* PLACE */}
               {selectedEvent.place ? (
-                <div>
+                <a
+                  href={`https://www.google.com/maps/search/?api=1&query=${selectedEvent.place.replace(
+                    " ",
+                    "+"
+                  )}`}
+                >
                   <p></p>
                   <i className="bi bi-geo-alt-fill"></i> {selectedEvent.place}
-                </div>
+                </a>
               ) : (
                 ""
               )}

--- a/components/EventModal/EventModal.tsx
+++ b/components/EventModal/EventModal.tsx
@@ -98,6 +98,8 @@ function EventModal({
                     " ",
                     "+"
                   )}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
                 >
                   <p></p>
                   <i className="bi bi-geo-alt-fill"></i> {selectedEvent.place}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,10 +13,10 @@ import Layout from "../components/Layout";
 import EventModal from "../components/EventModal";
 import styles from "../styles/events.module.css";
 import { IEventDTO } from "../dtos";
-import { reduceOpacity, defaultColors } from "../utils";
+import { reduceOpacity, defaultColors, getEvents } from "../utils";
 import { SubjectColor } from "../types";
 
-import { google, sheets_v4 } from "googleapis";
+import { google } from "googleapis";
 
 export interface IFormatedEvent {
   title: string;
@@ -291,99 +291,8 @@ export default function Home({ events, filters }) {
   );
 }
 
-async function getEvents(sheets: sheets_v4.Sheets): Promise<IEventDTO[]> {
-  const range = "Eventos!A2:I999";
-  const response = await sheets.spreadsheets.values.get({
-    spreadsheetId: process.env.SHEET_ID,
-    range,
-  });
-
-  let events: IEventDTO[] = [];
-  const rows: string[][] = response.data.values;
-  if (rows.length) {
-    /* Look, Netlify has some freaking problem with daylight savings, and it just won't get the Europe/Lisbon DST right.
-     * That said, the following code manually fixes what Netlify messes up, by pretty much checking if the dates are
-     * between the DST period for Portugal (manually set bellow) and, if so, subtracting 1 hour from the date.
-     *
-     * Is this optimal? No. Have I tried to fix it in a better way? Yes. Did I succeed? No.
-     *
-     * Do we need to update the DST period every year? Yes. Is it a big deal? No.
-     *
-     * Do I give up fixing this issue? Yes.
-     *
-     * If you have a better solution, please, PLEASE, let me know.
-     * */
-
-    // check if the date is between the DST period for Portugal, and if so, subtract 1 hour
-    const fixDST = (date: Date) => {
-      date.getTime() > dstStart.getTime() &&
-        date.getTime() < dstEnd.getTime() &&
-        date.setHours(date.getHours() - 1);
-      return date;
-    };
-
-    // convert a date to a string in the format "YYYY-MM-DD HH:MM"
-    // no, there isn't a js function that converts Date to String in this format
-    const dateToString = (date: Date) => {
-      return (
-        date.getFullYear() +
-        "-" +
-        (date.getMonth() + 1) +
-        "-" +
-        date.getDate() +
-        " " +
-        date.getHours() +
-        ":" +
-        date.getMinutes()
-      );
-    };
-
-    // DST period for Portugal, current: 26/03/2023 - 29/10/2023
-    const dstStart = new Date(new Date().getFullYear(), 2, 26);
-    const dstEnd = new Date(new Date().getFullYear(), 9, 29);
-
-    events = rows.map((row: string[]) => {
-      // dates that will ultimatly be passed into `events`
-      let startString: string = undefined;
-      let endString: string = undefined;
-
-      // check if the date rows exist in the first place, before messing with them
-      if (row[3] && row[4] && row[5] && row[6]) {
-        // auxiliary variables needed to perform operations on Date objects
-        let start: Date = new Date(row[3] + " " + row[4]);
-        let end: Date = new Date(row[5] + " " + row[6]);
-
-        // fix DST if necessary
-        start = fixDST(start);
-        end = fixDST(end);
-
-        // convert the dates back to strings.
-        // this is needed because the contents of `events` need to be serializable, and Date objects are not
-        // they need to be serialized because of `getServerSideProps()`
-        startString = dateToString(start);
-        endString = dateToString(end);
-      }
-
-      /* The End. */
-
-      return {
-        title: row[0] ?? undefined,
-        place: row[1] ?? undefined,
-        link: row[2] ?? undefined,
-        start: startString,
-        end: endString,
-        groupId: row[7] ? parseInt(row[7]) : undefined,
-        filterId: row[8] ? parseInt(row[8]) : undefined,
-      };
-    });
-
-    return events.filter(
-      (e) => e.title && e.start && e.end && e.groupId && e.filterId
-    ); // filter out invalid/incomplete events
-  }
-}
-
 export async function getServerSideProps() {
+  // Connect to Google API
   const target = ["https://www.googleapis.com/auth/spreadsheets.readonly"];
   const jwt = new google.auth.JWT(
     process.env.GS_CLIENT_EMAIL,

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,3 +1,6 @@
+import { IEventDTO } from "../dtos";
+import { sheets_v4 } from "googleapis";
+
 export function reduceOpacity(hexColor) {
   // Convert HEX color code to RGBA color code
   let r = parseInt(hexColor.slice(1, 3), 16);
@@ -10,7 +13,7 @@ export function reduceOpacity(hexColor) {
 }
 
 export const defaultColors = [
-  "#f07c54", // cesium
+  "#ed7950", // cesium
   "#4BC0D9", // 1st year
   "#7b54f0", // 2nd year
   "#f0547b", // 3rd year
@@ -23,3 +26,102 @@ export const defaultColors = [
   "#1B69EE", // jordi
   "#FF499E", // codeweek
 ];
+
+export async function getEvents(
+  sheets: sheets_v4.Sheets
+): Promise<IEventDTO[]> {
+  const range = "Eventos!A2:I999";
+  const response = await sheets.spreadsheets.values.get({
+    spreadsheetId: process.env.SHEET_ID,
+    range,
+  });
+
+  let events: IEventDTO[] = [];
+  const rows: string[][] = response.data.values;
+  if (rows.length) {
+    /* Look, Netlify has some freaking problem with daylight savings, and it just won't get the Europe/Lisbon DST right.
+     * That said, the following code manually fixes what Netlify messes up, by pretty much checking if the dates are
+     * between the DST period for Portugal (manually set bellow) and, if so, subtracting 1 hour from the date.
+     *
+     * Is this optimal? No. Have I tried to fix it in a better way? Yes. Did I succeed? No.
+     *
+     * Do we need to update the DST period every year? Yes. Is it a big deal? No.
+     *
+     * Do I give up fixing this issue? Yes.
+     *
+     * If you have a better solution, please, PLEASE, let me know.
+     * */
+
+    // check if the date is between the DST period for Portugal, and if so, subtract 1 hour
+    const fixDST = (date: Date) => {
+      date.getTime() > dstStart.getTime() &&
+        date.getTime() < dstEnd.getTime() &&
+        date.setHours(date.getHours() - 1);
+      return date;
+    };
+
+    // convert a date to a string in the format "YYYY-MM-DD HH:MM"
+    // no, there isn't a js function that converts Date to String in this format
+    const dateToString = (date: Date) => {
+      return (
+        date.getFullYear() +
+        "-" +
+        (date.getMonth() + 1) +
+        "-" +
+        date.getDate() +
+        " " +
+        date.getHours() +
+        ":" +
+        date.getMinutes()
+      );
+    };
+
+    // DST period for Portugal, current: 26/03/2023 - 29/10/2023
+    const dstStart = new Date(new Date().getFullYear(), 2, 26);
+    const dstEnd = new Date(new Date().getFullYear(), 9, 29);
+
+    events = rows.map((row: string[]) => {
+      // dates that will ultimatly be passed into `events`
+      let startString: string = undefined;
+      let endString: string = undefined;
+
+      // check if the date rows exist in the first place, before messing with them
+      if (row[3] && row[4] && row[5] && row[6]) {
+        // auxiliary variables needed to perform operations on Date objects
+        let start: Date = new Date(row[3] + " " + row[4]);
+        let end: Date = new Date(row[5] + " " + row[6]);
+
+        // fix DST if necessary
+        start = fixDST(start);
+        end = fixDST(end);
+
+        // convert the dates back to strings.
+        // this is needed because the contents of `events` need to be serializable, and Date objects are not
+        // they need to be serialized because of `getServerSideProps()`
+        startString = dateToString(start);
+        endString = dateToString(end);
+      }
+
+      /* The End. */
+
+      return {
+        title: row[0] ?? undefined,
+        place: row[1] ?? undefined,
+        link: row[2] ?? undefined,
+        start: startString,
+        end: endString,
+        groupId: row[7] ? parseInt(row[7]) : undefined,
+        filterId: row[8] ? parseInt(row[8]) : undefined,
+      };
+    });
+
+    return events.filter(
+      (e) =>
+        e.title != undefined &&
+        e.start != undefined &&
+        e.end != undefined &&
+        e.groupId != undefined &&
+        e.filterId != undefined
+    ); // filter out invalid/incomplete events
+  }
+}


### PR DESCRIPTION
Fixed a bug that caused events with the `groupId` parameter set to `0` to be considered invalid. This happened because the value `0` would be read as `false` in the if condition.

In the process of solving this, I also made some improvements to the way dates and times are shown in `EventModal`, particularly for events that extend for multiple days AND have a specific start hour and end hour, for example Karaoke, that goes from 28/11 at 21:00 to 29/11 at 02:00.

Also made the event location a link that takes the the user to Google Maps and automatically searches for the location. 

- fix: events with `groupId` set to `0` won't show
- style: improve the way dates are displayed
