### PR TITLE
feat: markdown for notifications

### DIFF
--- a/components/Notifications/Notifications.tsx
+++ b/components/Notifications/Notifications.tsx
@@ -59,7 +59,7 @@ const Banner = ({
       } ease fixed inset-x-0 bottom-0 z-20 m-auto transform transition duration-300 sm:flex sm:max-w-8/10 sm:justify-center sm:pb-4`}
     >
       <div className="flex items-center justify-between gap-x-6 bg-cesium-900 px-6 py-2.5 pb-6 sm:rounded-xl sm:py-3 sm:pl-4 sm:pr-3.5 sm:shadow-md">
-        <div className="select-none text-sm leading-6 text-white">
+        <div className="select-none font-display text-sm leading-6 text-white">
           <div>
             <strong className="font-semibold">
               <i className="bi bi-info-circle-fill"></i> {type}

--- a/components/Notifications/Notifications.tsx
+++ b/components/Notifications/Notifications.tsx
@@ -2,6 +2,10 @@ import React from "react";
 
 import moment from "moment-timezone";
 
+import Markdown from "markdown-to-jsx";
+
+import { render } from "react-dom";
+
 import { INotDTO } from "../../dtos";
 
 type BannerProps = {
@@ -67,7 +71,21 @@ const Banner = ({
             >
               <circle cx={1} cy={1} r={1} />
             </svg>
-            {description}
+            <Markdown
+              options={{
+                overrides: {
+                  a: {
+                    props: {
+                      className: "hover:underline",
+                      target: "_blank",
+                      rel: "noopener noreferrer",
+                    },
+                  },
+                },
+              }}
+            >
+              {description}
+            </Markdown>
           </div>
         </div>
         <div className="flex justify-between gap-x-5 sm:gap-x-3">

--- a/components/Notifications/Notifications.tsx
+++ b/components/Notifications/Notifications.tsx
@@ -4,8 +4,6 @@ import moment from "moment-timezone";
 
 import Markdown from "markdown-to-jsx";
 
-import { render } from "react-dom";
-
 import { INotDTO } from "../../dtos";
 
 type BannerProps = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "html2canvas": "^1.4.1",
         "ical-generator": "^5.0.1",
         "jspdf": "^2.5.1",
+        "markdown-to-jsx": "^7.4.0",
         "next": "^13.4.19",
         "next-pwa": "^5.6.0",
         "npm-run-all": "^4.1.5",
@@ -7895,6 +7896,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.0.tgz",
+      "integrity": "sha512-zilc+MIkVVXPyTb4iIUTIz9yyqfcWjszGXnwF9K/aiBWcHXFcmdEMTkG01/oQhwSCH7SY1BnG6+ev5BzWmbPrg==",
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -18079,6 +18091,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
+    },
+    "markdown-to-jsx": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.0.tgz",
+      "integrity": "sha512-zilc+MIkVVXPyTb4iIUTIz9yyqfcWjszGXnwF9K/aiBWcHXFcmdEMTkG01/oQhwSCH7SY1BnG6+ev5BzWmbPrg==",
+      "requires": {}
     },
     "mathml-tag-names": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "html2canvas": "^1.4.1",
     "ical-generator": "^5.0.1",
     "jspdf": "^2.5.1",
+    "markdown-to-jsx": "^7.4.0",
     "next": "^13.4.19",
     "next-pwa": "^5.6.0",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Added compatibility for markdown in the notification descriptions, this markdown is taken as a string and converted to html and then JSX. To achieve this, I installed the following (very light) npm package: [markdown-to-jsx](https://www.npmjs.com/package/markdown-to-jsx).
