### PR TITLE
feat: dark mode

### DIFF
--- a/components/CalendarExportModal/CalendarExportModal.tsx
+++ b/components/CalendarExportModal/CalendarExportModal.tsx
@@ -138,7 +138,7 @@ const CalendarExportModal = ({
       >
         <Fade in={isOpen} timeout={400}>
           <Box
-            className="absolute left-1/2 top-1/2 h-fit w-full -translate-x-1/2 -translate-y-1/2 transform overflow-y-auto rounded-2xl border bg-white p-6 text-center shadow-xl sm:w-96"
+            className="absolute left-1/2 top-1/2 h-fit w-full -translate-x-1/2 -translate-y-1/2 transform overflow-y-auto rounded-2xl border dark:border-neutral-400/20 bg-white dark:bg-neutral-800 p-6 text-center shadow-xl sm:w-96"
             style={{
               maxHeight: "calc(100% - 4rem)",
               maxWidth: "calc(100% - 4rem)",
@@ -167,7 +167,7 @@ const CalendarExportModal = ({
                           className="relative flex flex-grow items-stretch focus-within:z-10"
                           style={{ width: "calc(100% - 38px)" }}
                         >
-                          <div className="block w-full rounded-none rounded-l-lg border-0 py-1.5  ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-cesium-900 sm:text-sm sm:leading-6">
+                          <div className="block w-full rounded-none rounded-l-lg border-0 py-1.5  ring-1 ring-inset ring-neutral-300 dark:ring-neutral-400/30 focus:ring-2 focus:ring-inset focus:ring-cesium-900 sm:text-sm sm:leading-6">
                             <div className="mx-2 overflow-y-hidden overflow-x-scroll whitespace-nowrap text-start">
                               {URL}
                             </div>
@@ -176,7 +176,7 @@ const CalendarExportModal = ({
                         <button
                           type="button"
                           title={isCopied ? "Copied" : "Copy"}
-                          className="relative -ml-px inline-flex w-[38px] place-content-center items-center gap-x-1.5 rounded-r-lg px-3 py-2 text-sm font-semibold  ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+                          className="relative -ml-px inline-flex w-[38px] place-content-center items-center gap-x-1.5 rounded-r-lg px-3 py-2 text-sm font-semibold  ring-1 ring-inset ring-neutral-300 dark:ring-neutral-400/30 dark:hover:bg-neutral-400/10 hover:bg-neutral-50"
                           onClick={copyToClipboard}
                         >
                           {isCopied ? (
@@ -188,7 +188,7 @@ const CalendarExportModal = ({
                       </div>
                     </div>
                   </span>
-                  <Collapse className="w-full rounded-lg border-gray-300 bg-white text-left font-display shadow-sm">
+                  <Collapse className="w-full rounded-lg border-neutral-300 bg-white dark:border-neutral-400/30 text-left font-display shadow-sm">
                     <Collapse.Panel header="How does it work?" key="1">
                       <div className="text-justify">
                         <p>
@@ -234,7 +234,7 @@ const CalendarExportModal = ({
                   </Collapse>
                   <Collapse
                     accordion
-                    className="w-full rounded-lg border-gray-300 bg-white text-left font-display shadow-sm"
+                    className="w-full rounded-lg border-neutral-300 bg-white text-left font-display shadow-sm"
                   >
                     <Collapse.Panel header="Google Calendar" key="1">
                       <div className="">
@@ -341,7 +341,7 @@ const CalendarExportModal = ({
                       </div>
                     </Collapse.Panel>
                   </Collapse>
-                  <div className="cursor-pointer select-none text-sm text-gray-500">
+                  <div className="cursor-pointer select-none text-sm text-neutral-500 dark:text-neutral-400">
                     {isHome ? (
                       <div title="To export your schedule please go to /schedule.">
                         <i className="bi bi-info-circle-fill"></i> Currently
@@ -356,7 +356,7 @@ const CalendarExportModal = ({
                     )}
                   </div>
 
-                  <div className="cursor-pointer select-none text-sm text-gray-500">
+                  <div className="cursor-pointer select-none text-sm text-neutral-500 dark:text-neutral-400">
                     <i className="bi bi-lightbulb"></i> You can also{" "}
                     <a className="font-medium text-blue-400" href={URL}>
                       download as .ics file

--- a/components/ClearScheduleButton/ClearScheduleButton.tsx
+++ b/components/ClearScheduleButton/ClearScheduleButton.tsx
@@ -27,7 +27,7 @@ const ClearScheduleButton = ({
       disabled={isSettings}
     >
       <button
-        className={`h-10 w-10 rounded-xl p-2 font-medium leading-3 text-error/50 shadow-md ring-1 ring-zinc-200/50 transition-all duration-300 hover:text-error hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 ${
+        className={`h-10 w-10 rounded-xl p-2 font-medium leading-3 text-error/50 dark:text-red-400/60 shadow-md ring-1 ring-neutral-200/50 dark:ring-neutral-400/20 transition-all duration-300 hover:text-error hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-neutral-800/70 ${
           isSettings && "cursor-not-allowed hover:text-error/50"
         }`}
         type="button"

--- a/components/DarkModeToggler/DarkModeToggler.tsx
+++ b/components/DarkModeToggler/DarkModeToggler.tsx
@@ -1,12 +1,12 @@
 import { Switch } from '@headlessui/react'
-import {useTheme} from 'next-themes';
+import { useTheme } from 'next-themes';
 
 function classNames(...classes) {
     return classes.filter(Boolean).join(' ')
   }
 
 const DarkModeToggler = () => {
-    const {theme, setTheme} = useTheme();
+    const { theme, setTheme } = useTheme();
 
     return (
         <div>

--- a/components/DarkModeToggler/DarkModeToggler.tsx
+++ b/components/DarkModeToggler/DarkModeToggler.tsx
@@ -11,7 +11,7 @@ const DarkModeToggler = () => {
     return (
         <div>
             <label className="block text-sm font-medium leading-6">
-                Dark Mode
+                Appearance
             </label>
             <select
                 id="theme"

--- a/components/DarkModeToggler/DarkModeToggler.tsx
+++ b/components/DarkModeToggler/DarkModeToggler.tsx
@@ -1,0 +1,37 @@
+import { Switch } from '@headlessui/react'
+import {useTheme} from 'next-themes';
+
+function classNames(...classes) {
+    return classes.filter(Boolean).join(' ')
+  }
+
+const DarkModeToggler = () => {
+    const {theme, setTheme} = useTheme();
+
+    return (
+        <div>
+            <label className="block text-sm font-medium leading-6">
+                Dark Mode
+            </label>
+            <Switch
+                checked={theme === 'dark'}
+                onChange={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+                className={classNames(
+                    theme === 'dark' ? 'bg-cesium-900' : 'bg-neutral-200 dark:bg-neutral-700',
+                    'mt-2 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-cesium-900 focus:ring-offset-2'
+                )}
+            >
+            <span className="sr-only">Use setting</span>
+            <span
+                aria-hidden="true"
+                className={classNames(
+                    theme === 'dark' ? 'translate-x-5' : 'translate-x-0',
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out'
+                )}
+            />
+            </Switch>
+        </div>
+    )
+}
+
+export default DarkModeToggler;

--- a/components/DarkModeToggler/DarkModeToggler.tsx
+++ b/components/DarkModeToggler/DarkModeToggler.tsx
@@ -13,23 +13,17 @@ const DarkModeToggler = () => {
             <label className="block text-sm font-medium leading-6">
                 Dark Mode
             </label>
-            <Switch
-                checked={theme === 'dark'}
-                onChange={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-                className={classNames(
-                    theme === 'dark' ? 'bg-cesium-900' : 'bg-neutral-200 dark:bg-neutral-700',
-                    'mt-2 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-cesium-900 focus:ring-offset-2'
-                )}
-            >
-            <span className="sr-only">Use setting</span>
-            <span
-                aria-hidden="true"
-                className={classNames(
-                    theme === 'dark' ? 'translate-x-5' : 'translate-x-0',
-                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out'
-                )}
-            />
-            </Switch>
+            <select
+                id="theme"
+                name="theme"
+                className="mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10  ring-1 ring-inset ring-neutral-300 dark:ring-neutral-400/20 focus:ring-2 focus:ring-cesium-900 dark:bg-neutral-800"
+                value={theme === "light" ? "Light" : theme === "dark" ? "Dark" : "Follow System"}
+                onChange={(e) => setTheme(e.target.value === "Light" ? "light" : e.target.value === "Dark" ? "dark" : "system")}
+                >
+                    <option>Follow System</option>
+                    <option>Dark</option>
+                    <option>Light</option>                
+            </select>
         </div>
     )
 }

--- a/components/DarkModeToggler/index.ts
+++ b/components/DarkModeToggler/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DarkModeToggler';

--- a/components/EventModal/EventModal.tsx
+++ b/components/EventModal/EventModal.tsx
@@ -59,11 +59,11 @@ function EventModal({
       >
         <Fade in={inspectEvent} timeout={400}>
           <Box
-            className="absolute left-1/2 top-1/2 h-fit w-fit min-w-[18rem] max-w-full -translate-x-1/2 -translate-y-1/2 transform rounded-2xl border border-zinc-200 bg-white p-6 text-center shadow-xl"
+            className="absolute left-1/2 top-1/2 h-fit w-fit min-w-[18rem] max-w-full -translate-x-1/2 -translate-y-1/2 transform rounded-2xl border border-neutral-200 bg-white dark:bg-neutral-800 dark:border-neutral-400/20 p-6 text-center shadow-xl"
             style={{ maxWidth: "calc(100% - 4rem)" }}
           >
             <div className="space-y-4 font-display">
-              <div className="m-auto w-fit border-b pb-4">
+              <div className="m-auto w-fit border-b dark:border-neutral-400/30 pb-4">
                 <span id="modal-modal-title" className="text-xl font-medium">
                   {selectedEvent.title}
                 </span>

--- a/components/ExportButton/ExportButton.tsx
+++ b/components/ExportButton/ExportButton.tsx
@@ -32,13 +32,13 @@ const ExportButton = ({ exportPDF, isHome, filters }: ExportButtonProps) => {
           leaveFrom="transform opacity-100 scale-100"
           leaveTo="transform opacity-0 scale-95"
         >
-          <Menu.Items className="absolute right-0 z-10 mt-2 w-fit origin-top-right overflow-hidden rounded-xl bg-white font-medium text-cesium-900 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+          <Menu.Items className="absolute right-0 z-10 mt-2 w-fit origin-top-right overflow-hidden rounded-xl bg-white dark:bg-neutral-800 font-medium text-cesium-900 dark:text-cesium-600 shadow-lg ring-1 ring-black  dark:ring-white/20 ring-opacity-5 focus:outline-none">
             <div className="grid grid-cols-1 py-1">
               <Menu.Item>
                 {({ active }) => (
                   <button
                     className={`${
-                      active && "bg-cesium-100"
+                      active && "bg-cesium-100 dark:bg-neutral-100/10"
                     } 'block text-sm' px-4 py-2`}
                     title="Add your events to your favorite calendar app."
                     onClick={() => setIsModalOpen(true)}
@@ -54,7 +54,7 @@ const ExportButton = ({ exportPDF, isHome, filters }: ExportButtonProps) => {
                 {({ active }) => (
                   <button
                     className={`${
-                      active && "bg-cesium-100"
+                      active && "bg-cesium-100 dark:bg-neutral-100/10"
                     } 'block text-sm' px-4 py-2`}
                     onClick={() => exportPDF()}
                   >

--- a/components/FilterBlock/FilterBlock.tsx
+++ b/components/FilterBlock/FilterBlock.tsx
@@ -277,9 +277,9 @@ const FilterBlock = ({
   };
 
   return (
-    <div className="select-none rounded-xl ring-1 ring-zinc-100/50">
+    <div className="select-none rounded-xl ring-1 ring-neutral-100/50 dark:ring-neutral-400/20">
       <Collapse
-        className="w-full rounded-xl bg-white font-display font-medium shadow-default"
+        className="w-full rounded-xl bg-white dark:bg-neutral-800/70 font-display font-medium shadow-default"
         bordered={false}
         accordion
       >
@@ -292,7 +292,7 @@ const FilterBlock = ({
               />
               <Collapse.Panel header={item1} key={item1 + "Panel"}>
                 <Collapse
-                  className="bg-white font-display font-medium"
+                  className="bg-white dark:bg-inherit font-display font-medium"
                   bordered={false}
                   accordion
                   key={item1 + "Collapse"}
@@ -310,7 +310,7 @@ const FilterBlock = ({
                           key={item1 + item2 + "Panel"}
                         >
                           <Collapse
-                            className="bg-white font-display font-normal"
+                            className="bg-white dark:bg-inherit font-display font-normal"
                             bordered={false}
                             accordion
                             key={item1 + item2 + "Collapse"}

--- a/components/Install/Install.tsx
+++ b/components/Install/Install.tsx
@@ -14,7 +14,7 @@ const Install = () => {
       </label>
       <button
         onClick={() => setIsModalOpen(true)}
-        className="mt-2 rounded-lg bg-cesium-100 p-2 font-medium text-cesium-900 shadow-sm transition-colors hover:bg-cesium-200"
+        className="mt-2 rounded-lg bg-cesium-100 dark:bg-cesium-700/20 dark:hover:bg-cesium-700/30 p-2 font-medium text-cesium-900 shadow-sm transition-colors hover:bg-cesium-200"
       >
         Install <i className="bi bi-download" />
       </button>
@@ -28,7 +28,7 @@ const Install = () => {
       >
         <Fade in={isModalOpen} timeout={400}>
           <Box
-            className="absolute left-1/2 top-1/2 h-fit w-full min-w-[18rem] max-w-full -translate-x-1/2 -translate-y-1/2 transform rounded-2xl border border-zinc-200 bg-white p-6 text-center shadow-xl sm:w-80"
+            className="absolute left-1/2 top-1/2 h-fit w-full min-w-[18rem] max-w-full -translate-x-1/2 -translate-y-1/2 transform rounded-2xl border border-neutral-200 bg-white dark:bg-neutral-800 dark:border-neutral-400/20 p-6 text-center shadow-xl sm:w-80"
             style={{
               maxHeight: "calc(100% - 4rem)",
               maxWidth: "calc(100% - 4rem)",
@@ -41,7 +41,7 @@ const Install = () => {
               >
                 Install Calendarium <i className="bi bi-download"></i>
               </span>
-              <div className="rounded-lg bg-blue-100 p-2 text-sm ">
+              <div className="rounded-lg bg-blue-500/20 p-2 text-sm ">
                 <i className="bi bi-info-circle-fill text-blue-500"></i> You can
                 install Calendarium as a{" "}
                 <a
@@ -55,7 +55,7 @@ const Install = () => {
                 <i className="bi bi-box-arrow-up-right"></i> on your device.
               </div>
               <Collapse
-                className="w-full rounded-lg border-gray-300 bg-white text-left font-display shadow-sm"
+                className="w-full rounded-lg border-neutral-300 bg-white text-left font-display shadow-sm"
                 accordion
               >
                 <Collapse.Panel header="Android" key="1">

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,12 +1,13 @@
 import { useState, ReactNode } from "react";
 
 import Link from "next/link";
-import Image from "next/image";
 
 import Sidebar from "../Sidebar";
 import Notifications from "../Notifications";
 
 import styles from "./layout.module.scss";
+
+import { useTheme } from "next-themes";
 
 interface ILayoutProps {
   children: ReactNode;
@@ -25,6 +26,7 @@ const Layout = ({
 }: ILayoutProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const hamburgerLine = `h-1 w-6 my-0.5 rounded-full bg-black transition ease transform duration-300 dark:bg-neutral-200 bg-neutral-900`;
+  const { theme } = useTheme();
 
   return (
     <div className="text-neutral-900 lg:flex dark:bg-neutral-900 dark:text-neutral-200">
@@ -66,7 +68,7 @@ const Layout = ({
             <picture>
               <img
                 className="h-[46px] w-auto"
-                src={"/calendarium-light.svg"}
+                src={theme === "dark" ? "/calendarium-dark.svg" : "/calendarium-light.svg"}
                 alt="Calendarium Logo"
               />
             </picture>

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { useState, ReactNode } from "react";
+import { useState, ReactNode, useEffect } from "react";
 
 import Link from "next/link";
 
@@ -25,8 +25,20 @@ const Layout = ({
   saveTheme,
 }: ILayoutProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const hamburgerLine = `h-1 w-6 my-0.5 rounded-full bg-black transition ease transform duration-300 dark:bg-neutral-200 bg-neutral-900`;
-  const { theme } = useTheme();
+  const hamburgerLine = `h-1 w-6 my-0.5 rounded-full bg-black transition ease transform duration-300 dark:bg-neutral-200 bg-neutral-900`; 
+  const { theme, setTheme } = useTheme();
+  const [logo, setLogo] = useState(null);
+
+  // necesary so logo renders only on the client
+  useEffect(() => setLogo(
+    <picture>
+      <img
+        className="h-[46px] w-auto"
+        src={theme === "dark" ? "/calendarium-dark.svg" : "/calendarium-light.svg"}
+        alt="Calendarium Logo"
+      />
+    </picture>
+  ), [theme]);
 
   return (
     <div className="text-neutral-900 lg:flex dark:bg-neutral-900 dark:text-neutral-200">
@@ -65,13 +77,7 @@ const Layout = ({
           style={{ cursor: "pointer", width: "fit-content", margin: "auto" }}
         >
           <Link href="/">
-            <picture>
-              <img
-                className="h-[46px] w-auto"
-                src={theme === "dark" ? "/calendarium-dark.svg" : "/calendarium-light.svg"}
-                alt="Calendarium Logo"
-              />
-            </picture>
+            {logo}
           </Link>
         </div>
       </div>

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -24,13 +24,13 @@ const Layout = ({
   saveTheme,
 }: ILayoutProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const hamburgerLine = `h-1 w-6 my-0.5 rounded-full bg-black transition ease transform duration-300`;
+  const hamburgerLine = `h-1 w-6 my-0.5 rounded-full bg-black transition ease transform duration-300 dark:bg-neutral-200 bg-neutral-900`;
 
   return (
-    <div className="text-gray-900 lg:flex">
+    <div className="text-neutral-900 lg:flex dark:bg-neutral-900 dark:text-neutral-200">
       {/* Open/Close Sidebar Button */}
       <button
-        className="group absolute z-20 ml-8 mt-8 flex h-12 w-12 flex-col items-center justify-center rounded-xl bg-white shadow-md ring-1 ring-zinc-100/50 lg:hidden"
+        className="group absolute z-20 ml-8 mt-8 flex h-12 w-12 flex-col items-center justify-center rounded-xl bg-white dark:bg-neutral-800/70 shadow-md ring-1 ring-neutral-100/50 dark:ring-neutral-400/20 lg:hidden"
         onClick={() => setIsOpen(!isOpen)}
       >
         <div
@@ -62,12 +62,12 @@ const Layout = ({
         <div
           style={{ cursor: "pointer", width: "fit-content", margin: "auto" }}
         >
-          <Link href="https://cesium.link/">
+          <Link href="/">
             <picture>
               <img
                 className="h-[46px] w-auto"
                 src={"/calendarium-light.svg"}
-                alt="CeSIUM Link"
+                alt="Calendarium Logo"
               />
             </picture>
           </Link>

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -26,7 +26,7 @@ const Layout = ({
 }: ILayoutProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const hamburgerLine = `h-1 w-6 my-0.5 rounded-full bg-black transition ease transform duration-300 dark:bg-neutral-200 bg-neutral-900`; 
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme } = useTheme();
   const [logo, setLogo] = useState(null);
 
   // necesary so logo renders only on the client
@@ -34,11 +34,11 @@ const Layout = ({
     <picture>
       <img
         className="h-[46px] w-auto"
-        src={theme === "dark" ? "/calendarium-dark.svg" : "/calendarium-light.svg"}
+        src={resolvedTheme === "dark" ? "/calendarium-dark.svg" : "/calendarium-light.svg"}
         alt="Calendarium Logo"
       />
     </picture>
-  ), [theme]);
+  ), [resolvedTheme]);
 
   return (
     <div className="text-neutral-900 lg:flex dark:bg-neutral-900 dark:text-neutral-200">

--- a/components/NavigationPane/NavigationPane.tsx
+++ b/components/NavigationPane/NavigationPane.tsx
@@ -5,15 +5,15 @@ const NavigationPane = () => {
   const { asPath } = useRouter();
 
   return (
-    <div className="rounded-xl font-display ring-1 ring-zinc-100/50">
-      <div className="flex w-full place-content-between rounded-xl p-5 font-medium text-gray-300 shadow-default transition-all">
+    <div className="rounded-xl font-display ring-1 ring-neutral-100/50 dark:ring-neutral-400/20 dark:bg-neutral-800/70">
+      <div className="flex w-full place-content-between rounded-xl p-5 font-medium text-neutral-300 dark:text-neutral-500 shadow-default transition-all">
         <div className="m-auto w-fit space-x-8">
           <Link href="/">
             <span
               className={`${
                 asPath === "/" &&
-                "text-gray-900 after:absolute after:ml-4 after:mt-4 after:flex after:h-1 after:w-12 after:rounded-t after:bg-cesium-900"
-              } transition-all hover:text-gray-900`}
+                "text-neutral-900 dark:text-neutral-200 after:absolute after:ml-4 after:mt-4 after:flex after:h-1 after:w-12 after:rounded-t after:bg-cesium-900"
+              } transition-all hover:text-neutral-900 dark:hover:text-neutral-200`}
             >
               <i className="bi bi-calendar-fill"></i> EVENTS
             </span>
@@ -22,8 +22,8 @@ const NavigationPane = () => {
             <span
               className={`${
                 asPath === "/schedule" &&
-                "text-gray-900 after:absolute after:ml-36 after:mt-4 after:flex after:h-1 after:w-12 after:rounded-t after:bg-cesium-900"
-              } transition-all hover:text-gray-900`}
+                "text-neutral-900 dark:text-neutral-200 after:absolute after:ml-36 after:mt-4 after:flex after:h-1 after:w-12 after:rounded-t after:bg-cesium-900"
+              } transition-all hover:text-neutral-900 dark:hover:text-neutral-200`}
             >
               <i className="bi bi-clock-fill"></i> SCHEDULE
             </span>

--- a/components/Settings/Settings.tsx
+++ b/components/Settings/Settings.tsx
@@ -2,6 +2,7 @@ import { IFilterDTO } from "../../dtos";
 
 import Themes from "../Themes";
 import Install from "../Install";
+import DarkModeToggler from "../DarkModeToggler";
 
 type SettingsProps = {
   saveTheme: () => void;
@@ -19,10 +20,10 @@ const Settings = ({
   isHome,
 }: SettingsProps) => {
   return (
-    <div className="h-full w-full select-none space-y-4 overflow-hidden rounded-xl p-4 shadow-default ring-1 ring-zinc-200/30">
+    <div className="h-full w-full select-none space-y-4 overflow-hidden rounded-xl p-4 shadow-default ring-1 ring-neutral-200/30 dark:ring-neutral-400/20 dark:bg-neutral-800/70">
       {/* Title */}
       <div className="text-center text-lg font-medium">Settings</div>
-      <div className="border-b border-zinc-200/80" />
+      <div className="border-b border-neutral-200/80 dark:border-neutral-400/30" />
       {/* Configs */}
       <Themes
         saveTheme={saveTheme}
@@ -31,6 +32,7 @@ const Settings = ({
         setIsOpen={setIsOpen}
         isHome={isHome}
       />
+      <DarkModeToggler />
       <Install />
     </div>
   );

--- a/components/ShareButton/ShareButton.tsx
+++ b/components/ShareButton/ShareButton.tsx
@@ -24,7 +24,7 @@ const ShareButton = ({
   return (
     <div>
       <button
-        className="h-10 w-10 rounded-xl p-2 font-medium leading-3 text-gray-300 shadow-md ring-1 ring-zinc-200/50 transition-all duration-300 hover:text-gray-900 hover:shadow-lg"
+        className="h-10 w-10 rounded-xl p-2 font-medium leading-3 text-neutral-300 dark:text-neutral-500 shadow-md ring-1 ring-neutral-200/50 dark:ring-neutral-400/20 transition-all duration-300 hover:text-neutral-900 dark:hover:text-neutral-200 hover:shadow-lg dark:bg-neutral-800/70"
         title="Share"
         onClick={() => setIsModalOpen(true)}
       >

--- a/components/ShareModal/ShareModal.tsx
+++ b/components/ShareModal/ShareModal.tsx
@@ -208,7 +208,7 @@ const ShareModal = ({
       >
         <Fade in={isOpen} timeout={400}>
           <Box
-            className="absolute left-1/2 top-1/2 h-fit w-80 -translate-x-1/2 -translate-y-1/2 transform overflow-y-auto rounded-2xl border bg-white p-6 text-center shadow-xl"
+            className="absolute left-1/2 top-1/2 h-fit w-80 -translate-x-1/2 -translate-y-1/2 transform overflow-y-auto rounded-2xl border bg-white dark:bg-neutral-800 dark:border-neutral-400/20 p-6 text-center shadow-xl"
             style={{
               maxHeight: "calc(100% - 4rem)",
               maxWidth: "calc(100% - 4rem)",
@@ -232,13 +232,13 @@ const ShareModal = ({
                       <div className="relative flex flex-grow items-stretch focus-within:z-10">
                         <input
                           name="link"
-                          className="block w-full rounded-none rounded-l-lg border-0 py-1.5 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-cesium-900 sm:text-sm sm:leading-6"
+                          className="block w-full rounded-none rounded-l-lg border-0 py-1.5 ring-1 ring-inset ring-neutral-300 dark:ring-neutral-400/30 dark:bg-neutral-800 placeholder:text-neutral-400 focus:ring-2 focus:ring-inset focus:ring-cesium-900 sm:text-sm sm:leading-6"
                           placeholder="Insert a share link here..."
                         />
                       </div>
                       <button
                         type="submit"
-                        className="relative -ml-px inline-flex w-[38px] place-content-center items-center gap-x-1.5 rounded-r-lg px-3 py-2 text-sm font-semibold ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+                        className="relative -ml-px inline-flex w-[38px] place-content-center items-center gap-x-1.5 rounded-r-lg px-3 py-2 text-sm font-semibold ring-1 ring-inset ring-neutral-300 dark:ring-neutral-400/30 dark:hover:bg-neutral-400/10 hover:bg-neutral-50"
                         title="Import"
                       >
                         {isImporting ? (
@@ -274,7 +274,7 @@ const ShareModal = ({
                     </form>
                     <button
                       type="button"
-                      className="relative ml-2 inline-flex items-center rounded-lg px-3 py-2 text-sm font-semibold shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+                      className="relative ml-2 inline-flex items-center rounded-lg px-3 py-2 text-sm font-semibold shadow-sm ring-1 ring-inset ring-neutral-300 dark:ring-neutral-400/30 dark:hover:bg-neutral-400/10 hover:bg-neutral-50"
                       title="Copy your share link"
                       onClick={copyToClipboard}
                     >
@@ -287,7 +287,7 @@ const ShareModal = ({
                   </div>
                 </div>
               </div>
-              <Collapse className="w-full rounded-lg border-gray-300 bg-white text-left font-display shadow-sm">
+              <Collapse className="w-full rounded-lg border-neutral-300 bg-white text-left font-display shadow-sm">
                 <Collapse.Panel header="How does it work?" key="1">
                   <div className="text-justify">
                     <a className="font-medium">

--- a/components/ShiftModal/ShiftModal.tsx
+++ b/components/ShiftModal/ShiftModal.tsx
@@ -49,11 +49,11 @@ function ShiftModal({
       >
         <Fade in={inspectShift} timeout={400}>
           <Box
-            className="absolute left-1/2 top-1/2 h-fit w-fit min-w-[18rem] -translate-x-1/2 -translate-y-1/2 transform rounded-2xl border border-zinc-200 bg-white p-6 text-center shadow-xl"
+            className="absolute left-1/2 top-1/2 h-fit w-fit min-w-[18rem] -translate-x-1/2 -translate-y-1/2 transform rounded-2xl border border-neutral-200 bg-white dark:bg-neutral-800 dark:border-neutral-400/20 p-6 text-center shadow-xl"
             style={{ maxWidth: "calc(100% - 4rem)" }}
           >
             <div className="space-y-4 font-display">
-              <div className="m-auto w-fit border-b pb-4">
+              <div className="m-auto w-fit border-b dark:border-neutral-400/30 pb-4">
                 <span id="modal-modal-title" className="text-xl font-medium">
                   {name}
                 </span>

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 import Link from "next/link";
 
@@ -59,6 +59,18 @@ const Sidebar = ({
   const sidebar = `lg:w-96 lg:block lg:translate-x-0 lg:h-full h-mobile lg:shadow-md lg:border-y lg:border-r dark:border-neutral-400/30 w-full absolute overflow-y-scroll overflow-x-hidden lg:overflow-y-scroll lg:rounded-r-3xl lg:py-8 pb-8 px-8 bg-white dark:bg-neutral-900 z-10 transition ease transform duration-300`;
 
   const { theme } = useTheme();
+  const [logo, setLogo] = useState(null);
+
+  // necesary so logo renders only on the client
+  useEffect(() => setLogo(
+    <picture>
+      <img
+        className="h-[46px] w-auto"
+        src={theme === "dark" ? "/calendarium-dark.svg" : "/calendarium-light.svg"}
+        alt="Calendarium Logo"
+      />
+    </picture>
+  ), [theme]);
 
   return (
     <div
@@ -72,13 +84,7 @@ const Sidebar = ({
             style={{ cursor: "pointer", width: "fit-content", margin: "auto" }}
           >
             <Link href="https://cesium.link/">
-              <picture>
-                <img
-                  className="h-[46px] w-auto"
-                  src={theme === "dark" ? "/calendarium-dark.svg" : "/calendarium-light.svg"}
-                  alt="CeSIUM Link"
-                />
-              </picture>
+              {logo}
             </Link>
           </div>
         </div>

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -58,7 +58,7 @@ const Sidebar = ({
 
   const sidebar = `lg:w-96 lg:block lg:translate-x-0 lg:h-full h-mobile lg:shadow-md lg:border-y lg:border-r dark:border-neutral-400/30 w-full absolute overflow-y-scroll overflow-x-hidden lg:overflow-y-scroll lg:rounded-r-3xl lg:py-8 pb-8 px-8 bg-white dark:bg-neutral-900 z-10 transition ease transform duration-300`;
 
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
   const [logo, setLogo] = useState(null);
 
   // necesary so logo renders only on the client
@@ -66,11 +66,11 @@ const Sidebar = ({
     <picture>
       <img
         className="h-[46px] w-auto"
-        src={theme === "dark" ? "/calendarium-dark.svg" : "/calendarium-light.svg"}
+        src={resolvedTheme === "dark" ? "/calendarium-dark.svg" : "/calendarium-light.svg"}
         alt="Calendarium Logo"
       />
     </picture>
-  ), [theme]);
+  ), [resolvedTheme]);
 
   return (
     <div

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -58,7 +58,7 @@ const Sidebar = ({
 
   const sidebar = `lg:w-96 lg:block lg:translate-x-0 lg:h-full h-mobile lg:shadow-md lg:border-y lg:border-r dark:border-neutral-400/30 w-full absolute overflow-y-scroll overflow-x-hidden lg:overflow-y-scroll lg:rounded-r-3xl lg:py-8 pb-8 px-8 bg-white dark:bg-neutral-900 z-10 transition ease transform duration-300`;
 
-  const {theme, setTheme} = useTheme();
+  const { theme } = useTheme();
 
   return (
     <div

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -75,7 +75,7 @@ const Sidebar = ({
               <picture>
                 <img
                   className="h-[46px] w-auto"
-                  src={theme === "light" ? "/calendarium-light.svg" : "/calendarium-dark.svg"}
+                  src={theme === "dark" ? "/calendarium-dark.svg" : "/calendarium-light.svg"}
                   alt="CeSIUM Link"
                 />
               </picture>

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 
 import Link from "next/link";
-import Image from "next/image";
 
 import html2canvas from "html2canvas";
 import jsPDF from "jspdf";
@@ -17,6 +16,8 @@ import { IFilterDTO } from "../../dtos";
 import ShareButton from "../ShareButton";
 
 import { SelectedShift } from "../../types";
+
+import {useTheme} from 'next-themes';
 
 interface ISidebarProps {
   isHome?: boolean;
@@ -55,7 +56,9 @@ const Sidebar = ({
     pdf.save("calendario.pdf");
   };
 
-  const sidebar = `lg:w-96 lg:block lg:translate-x-0 lg:h-full h-mobile lg:shadow-md lg:border w-full absolute overflow-y-scroll overflow-x-hidden lg:overflow-y-scroll lg:rounded-r-3xl lg:py-8 pb-8 px-8 bg-white z-10 transition ease transform duration-300`;
+  const sidebar = `lg:w-96 lg:block lg:translate-x-0 lg:h-full h-mobile lg:shadow-md lg:border-y lg:border-r dark:border-neutral-400/30 w-full absolute overflow-y-scroll overflow-x-hidden lg:overflow-y-scroll lg:rounded-r-3xl lg:py-8 pb-8 px-8 bg-white dark:bg-neutral-900 z-10 transition ease transform duration-300`;
+
+  const {theme, setTheme} = useTheme();
 
   return (
     <div
@@ -72,7 +75,7 @@ const Sidebar = ({
               <picture>
                 <img
                   className="h-[46px] w-auto"
-                  src={"/calendarium-light.svg"}
+                  src={theme === "light" ? "/calendarium-light.svg" : "/calendarium-dark.svg"}
                   alt="CeSIUM Link"
                 />
               </picture>
@@ -89,11 +92,11 @@ const Sidebar = ({
             <div className="flex space-x-2">
               <button
                 onClick={() => setIsSettings(!isSettings)}
-                className="h-10 w-10 rounded-xl p-2 leading-3 text-gray-300 shadow-md ring-1 ring-zinc-200/50 transition-all duration-300 hover:text-gray-900 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500"
+                className="dark:bg-neutral-800/70 h-10 w-10 rounded-xl p-2 leading-3 text-neutral-300 dark:text-neutral-500 shadow-md ring-1 ring-neutral-200/50 dark:ring-neutral-400/20 transition-all duration-300 hover:text-neutral-900 dark:hover:text-neutral-200 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500"
                 title="Settings"
               >
                 {isSettings ? (
-                  <i className="bi bi-gear-fill text-gray-900"></i>
+                  <i className="bi bi-gear-fill text-neutral-900 dark:text-neutral-200"></i>
                 ) : (
                   <i className="bi bi-gear-fill"></i>
                 )}

--- a/components/Themes/Themes.tsx
+++ b/components/Themes/Themes.tsx
@@ -185,7 +185,7 @@ const Themes = ({ saveTheme, filters, isOpen, setIsOpen, isHome }) => {
         <select
           id="theme"
           name="theme"
-          className="mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10  ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-cesium-900"
+          className="mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10  ring-1 ring-inset ring-neutral-300 dark:ring-neutral-400/20 focus:ring-2 focus:ring-cesium-900 dark:bg-neutral-800"
           value={theme}
           onChange={(e) => updateTheme(e.target.value)}
         >
@@ -204,7 +204,7 @@ const Themes = ({ saveTheme, filters, isOpen, setIsOpen, isHome }) => {
             <select
               id="theme"
               name="theme"
-              className="block w-full rounded-md border-0 py-1.5  ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-cesium-900"
+              className="block w-full rounded-md border-0 py-1.5  ring-1 ring-inset ring-neutral-300 dark:ring-neutral-400/20 focus:ring-2 focus:ring-cesium-900 dark:bg-neutral-800"
               value={customType}
               onChange={(e) => updateCustomType(e.target.value)}
             >
@@ -243,12 +243,12 @@ const Themes = ({ saveTheme, filters, isOpen, setIsOpen, isHome }) => {
                 <div className="flex flex-row items-center space-x-2">
                   <div
                     title="A Hex color code, for example: #ed7950"
-                    className="cursor-default text-sm font-medium "
+                    className="cursor-default text-sm font-medium"
                   >
-                    Hex:
+                    Hex
                   </div>
                   <HexColorInput
-                    className="text-md h-8 w-full rounded-lg border-gray-300 text-center  focus:border-cesium-900 focus:ring-0"
+                    className="text-md h-8 w-full rounded-lg border-neutral-300 dark:border-neutral-400/20 dark:bg-neutral-800 text-center focus:border-cesium-900 focus:ring-0"
                     color={colors[openColor + 1]}
                     onChange={(newColor) => updateColors(newColor)}
                   />
@@ -260,7 +260,7 @@ const Themes = ({ saveTheme, filters, isOpen, setIsOpen, isHome }) => {
                     checked={opacity}
                     onChange={updateOpacity}
                     className={`${
-                      opacity ? "bg-cesium-900" : "bg-gray-200"
+                      opacity ? "bg-cesium-900" : "bg-neutral-200"
                     } ${"relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}`}
                   >
                     <span className="sr-only">Use setting</span>
@@ -277,7 +277,7 @@ const Themes = ({ saveTheme, filters, isOpen, setIsOpen, isHome }) => {
                 </Switch.Group>
                 <button
                   type="button"
-                  className="rounded-md border bg-white px-2.5 py-1 text-xs font-semibold  shadow-sm hover:bg-gray-50"
+                  className="rounded-md border bg-white dark:bg-neutral-800 dark:border-neutral-400/20 dark:hover:bg-neutral-700 px-2.5 py-1 text-xs font-semibold  shadow-sm hover:bg-neutral-50"
                   onClick={backToDefault}
                 >
                   Back to Default
@@ -316,10 +316,10 @@ const Themes = ({ saveTheme, filters, isOpen, setIsOpen, isHome }) => {
                     title="A Hex color code, for example: #ed7950"
                     className="cursor-default text-sm font-medium "
                   >
-                    Hex:
+                    Hex
                   </div>
                   <HexColorInput
-                    className="text-md h-8 w-full rounded-lg border-gray-300 text-center  focus:border-cesium-900 focus:ring-0"
+                    className="text-md h-8 w-full rounded-lg border-neutral-300 dark:border-neutral-400/20 dark:bg-neutral-800 text-center focus:border-cesium-900 focus:ring-0"
                     color={getSubjectColor(openColor)}
                     onChange={(newColor) => updateSubjectColors(newColor)}
                   />
@@ -331,7 +331,7 @@ const Themes = ({ saveTheme, filters, isOpen, setIsOpen, isHome }) => {
                     checked={opacity}
                     onChange={updateOpacity}
                     className={`${
-                      opacity ? "bg-cesium-900" : "bg-gray-200"
+                      opacity ? "bg-cesium-900" : "bg-neutral-200"
                     } ${"relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}`}
                   >
                     <span className="sr-only">Use setting</span>
@@ -348,7 +348,7 @@ const Themes = ({ saveTheme, filters, isOpen, setIsOpen, isHome }) => {
                 </Switch.Group>
                 <button
                   type="button"
-                  className="rounded-md border bg-white px-2.5 py-1 text-xs font-semibold  shadow-sm hover:bg-gray-50"
+                  className="rounded-md border bg-white dark:bg-neutral-800 dark:border-neutral-400/20 dark:hover:bg-neutral-700 px-2.5 py-1 text-xs font-semibold  shadow-sm hover:bg-neutral-50"
                   onClick={backToSubjectDefault}
                 >
                   Back to Default
@@ -364,7 +364,7 @@ const Themes = ({ saveTheme, filters, isOpen, setIsOpen, isHome }) => {
           {(customType === "Year" || checkedThings.length > 0) && (
             <button
               type="button"
-              className="w-full rounded-md bg-cesium-100 px-2 py-1 text-sm font-semibold text-cesium-900 shadow-sm transition-colors hover:bg-cesium-200"
+              className="w-full rounded-md bg-cesium-100 dark:bg-cesium-700/20 dark:hover:bg-cesium-700/30 px-2 py-1 text-sm font-semibold text-cesium-900 shadow-sm transition-colors hover:bg-cesium-200"
               onClick={() => {
                 saveTheme();
                 isOpen && setIsOpen(false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "markdown-to-jsx": "^7.4.0",
         "next": "^13.4.19",
         "next-pwa": "^5.6.0",
+        "next-themes": "^0.2.1",
         "npm-run-all": "^4.1.5",
         "react": "^18.2.0",
         "react-big-calendar": "^1.4.2",
@@ -8487,6 +8488,16 @@
       },
       "peerDependencies": {
         "next": ">=9.0.0"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+      "peerDependencies": {
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -18679,6 +18690,12 @@
         "workbox-webpack-plugin": "^6.5.4",
         "workbox-window": "^6.5.4"
       }
+    },
+    "next-themes": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+      "requires": {}
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "markdown-to-jsx": "^7.4.0",
     "next": "^13.4.19",
     "next-pwa": "^5.6.0",
+    "next-themes": "^0.2.1",
     "npm-run-all": "^4.1.5",
     "react": "^18.2.0",
     "react-big-calendar": "^1.4.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,13 @@
 import type { AppProps } from "next/app";
 import "../styles/globals.css";
+import {ThemeProvider} from 'next-themes';
 
 function Calendarium({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <ThemeProvider attribute="class" storageKey="darkTheme" defaultTheme="light">
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
 }
 
 export default Calendarium;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
 import type { AppProps } from "next/app";
 import "../styles/globals.css";
-import {ThemeProvider} from 'next-themes';
+import { ThemeProvider } from 'next-themes';
 
 function Calendarium({ Component, pageProps }: AppProps) {
   return (

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,7 +4,7 @@ import {ThemeProvider} from 'next-themes';
 
 function Calendarium({ Component, pageProps }: AppProps) {
   return (
-    <ThemeProvider attribute="class" storageKey="darkTheme" defaultTheme="light">
+    <ThemeProvider attribute="class" storageKey="darkTheme" defaultTheme="system">
       <Component {...pageProps} />
     </ThemeProvider>
   );

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -2,7 +2,7 @@ import { Html, Head, Main, NextScript } from "next/document";
 
 export default function Document() {
   return (
-    <Html lang="en">
+    <Html lang="en" className="dark">
       <Head>
         <link rel="manifest" href="/manifest.webmanifest" />
         <link rel="apple-touch-icon" href="/pwa/ios/512.png"></link>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -60,7 +60,7 @@ export default function Document() {
         />
         <meta name="theme-color" content="#ffffff" />
         {/* Status Bar configuration for IOS devices */}
-        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
       </Head>
       <body>
         <Main />

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -215,7 +215,7 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
   const maxDate = new Date();
   maxDate.setHours(20, 0, 0);
 
-  const {theme, setTheme} = useTheme();
+  const { theme } = useTheme();
 
   return (
     <Layout

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -20,6 +20,8 @@ import { defaultColors } from "../utils";
 
 import styles from "../styles/schedule.module.css";
 
+import { useTheme } from "next-themes";
+
 const localizer = momentLocalizer(moment);
 
 export interface IFormatedShift {
@@ -58,7 +60,7 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
 
   // THEMES
 
-  const [theme, setTheme] = useState<string>("Modern");
+  const [colorTheme, setColorTheme] = useState<string>("Modern");
   const [colors, setColors] = useState<string[]>(defaultColors);
   const [opacity, setOpacity] = useState<boolean>(true);
   const [subjectColors, setSubjectColors] = useState<SubjectColor[]>([]);
@@ -79,9 +81,9 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
   function getBgColor(event: IFormatedShift) {
     let color: string = "#000000";
 
-    if (theme === "Modern") color = reduceOpacity(getDefaultColor(event));
-    else if (theme === "Classic") color = getDefaultColor(event);
-    else if (theme === "Custom") {
+    if (colorTheme === "Modern") color = reduceOpacity(getDefaultColor(event));
+    else if (colorTheme === "Classic") color = getDefaultColor(event);
+    else if (colorTheme === "Custom") {
       if (customType === "Year") {
         opacity
           ? (color = reduceOpacity(colors[String(event.filterId)[0]]))
@@ -99,9 +101,9 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
   function getTextColor(event: IFormatedShift) {
     let color: string = "#000000";
 
-    if (theme === "Modern") color = getDefaultColor(event);
-    else if (theme === "Classic") color = "white";
-    else if (theme === "Custom") {
+    if (colorTheme === "Modern") color = getDefaultColor(event);
+    else if (colorTheme === "Classic") color = "white";
+    else if (colorTheme === "Custom") {
       if (customType === "Year") {
         opacity
           ? (color = colors[String(event.filterId)[0]])
@@ -130,7 +132,7 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
       theme = "Modern";
     }
 
-    setTheme(theme);
+    setColorTheme(theme);
     if (theme === "Custom") {
       setCustomType(customType);
 
@@ -213,6 +215,8 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
   const maxDate = new Date();
   maxDate.setHours(20, 0, 0);
 
+  const {theme, setTheme} = useTheme();
+
   return (
     <Layout
       isHome={false}
@@ -241,7 +245,7 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
           max={maxDate}
           eventPropGetter={(event) => {
             const newStyle = {
-              border: "2px solid white",
+              border: "2px solid " + (theme === "dark" ? "#171717" : "white"),
               backgroundColor: getBgColor(event),
               color: getTextColor(event),
               fontWeight: "500",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -111,6 +111,7 @@ a {
 .rbc-calendar .rbc-month-view {
   overflow: hidden;
   border: 1px solid rgb(203 213 225);
+  @apply dark:border-neutral-400/20;
   border-radius: 8px;
 }
 
@@ -124,6 +125,7 @@ a {
   font-weight: 500;
   color: #111827;
   border: 1px solid rgb(203 213 225);
+  @apply dark:border-neutral-400/20 dark:text-neutral-200;
   border-radius: 8px;
   box-shadow: none;
 }
@@ -131,46 +133,71 @@ a {
 .rbc-calendar .rbc-toolbar button:hover {
   color: #2c2e32;
   border: 1px solid rgb(203 213 225);
+  @apply dark:border-neutral-400/20 dark:text-neutral-200 dark:bg-white/10;
 }
 
 .rbc-calendar .rbc-toolbar button:focus {
   color: #2c2e32;
   border: 1px solid rgb(203 213 225);
+  @apply dark:border-neutral-400/20 dark:text-neutral-200 dark:bg-white/10;
 }
 
 .rbc-calendar .rbc-toolbar button:active {
   color: #2c2e32;
   border: 1px solid rgb(203 213 225);
+  @apply dark:border-neutral-400/20 dark:text-neutral-200 dark:bg-white/10;
 }
 
 .rbc-calendar .rbc-toolbar button.rbc-active {
   color: #2c2e32;
   border: 1px solid rgb(203 213 225);
+  @apply dark:border-neutral-400/20 dark:text-neutral-200 dark:bg-neutral-800;
+}
+
+.rbc-calendar .rbc-timeslot-group {
+  @apply dark:border-neutral-400/20;
+}
+
+.rbc-calendar .rbc-day-slot .rbc-time-slot {
+  @apply border-none;
+}
+
+.rbc-calendar .rbc-time-header-content {
+  @apply dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-toolbar button.rbc-active:hover {
   color: #2c2e32;
   border: 1px solid rgb(203 213 225);
+  @apply dark:border-neutral-400/20 dark:text-neutral-200 dark:bg-neutral-700/80;
 }
 
 .rbc-calendar .rbc-toolbar button.rbc-active:focus {
   color: #2c2e32;
   border: 1px solid rgb(203 213 225);
+  @apply dark:border-neutral-400/20 dark:text-neutral-200 dark:bg-neutral-700/80;
 }
 
 .rbc-calendar .rbc-toolbar button.rbc-active:active {
   color: #2c2e32;
   border: 1px solid rgb(203 213 225);
+  @apply dark:border-neutral-400/20 dark:text-neutral-200;
 }
 
 .rbc-calendar .rbc-header {
   padding: 0.15rem;
   font-weight: 500;
   color: #374151;
+  @apply dark:text-neutral-400 dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-off-range-bg {
   background-color: rgb(243 244 246);
+  @apply dark:bg-neutral-800/50;
+}
+
+.rbc-calendar .rbc-header + .rbc-header {
+  @apply dark:border-l dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-off-range {
@@ -185,18 +212,22 @@ a {
 
 .rbc-calendar .rbc-month-row {
   color: rgb(55 65 81);
+  @apply dark:text-neutral-400;
 }
 
 .rbc-calendar .rbc-month-row + .rbc-month-row {
   border-top: 1px solid rgb(226 232 240);
+  @apply dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-day-bg + .rbc-day-bg {
   border-left: 1px solid rgb(226 232 240);
+  @apply dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-rtl .rbc-day-bg + .rbc-day-bg {
   border-right: 1px solid rgb(226 232 240);
+  @apply dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-row-segment .rbc-event {
@@ -209,7 +240,7 @@ a {
 }
 
 .rbc-calendar .rbc-today {
-  background-color: #ed7a501b;
+  @apply bg-cesium-900/10;
 }
 
 .rbc-calendar .rbc-date-cell.rbc-now.rbc-current > button {
@@ -233,10 +264,16 @@ a {
 
 .rbc-calendar .rbc-time-content > * + * > * {
   border-left: 1px solid rgb(226 232 240);
+  @apply dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-rtl .rbc-time-content > * + * > * {
   border-right: 1px solid rgb(226 232 240);
+  @apply dark:border-neutral-400/20;
+}
+
+.rbc-calendar .rbc-time-content {
+  @apply dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-current-time-indicator {
@@ -247,41 +284,50 @@ a {
 
 .rbc-calendar .rbc-time-view-resources .rbc-time-header-gutter {
   border-right: 1px solid rgb(226 232 240);
+  @apply dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-time-header.rbc-overflowing {
   border-right: 1px solid rgb(226 232 240);
+  @apply dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-rtl .rbc-time-header.rbc-overflowing {
   border-left: 1px solid rgb(226 232 240);
+  @apply dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-time-header > .rbc-row:first-child {
   border-bottom: 1px solid rgb(226 232 240);
+  @apply dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-time-header > .rbc-row.rbc-row-resource {
   border-bottom: 1px solid rgb(226 232 240);
+  @apply dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-rtl .rbc-time-header-content {
   border-right: 1px solid rgb(226 232 240);
+  @apply dark:border-neutral-400/20;
 }
 
 .rbc-time-header-content > .rbc-row.rbc-row-resource {
   border-bottom: 1px solid rgb(226 232 240);
+  @apply dark:border-neutral-400/20;
 }
 
 .rbc-calendar .rbc-time-view {
   overflow: hidden;
   border: 1px solid rgb(203 213 225);
+  @apply dark:border-neutral-400/20;
   border-radius: 8px;
 }
 
 .rbc-calendar .rbc-label {
   font-size: small;
   color: rgb(55 65 81);
+  @apply dark:text-neutral-400;
   text-align: left;
 }
 
@@ -332,4 +378,56 @@ a {
   #byYear .react-colorful {
     width: 14rem;
   }
+}
+
+.ant-collapse-header-text {
+  @apply dark:text-neutral-200 text-neutral-900;
+}
+
+.ant-collapse-expand-icon {
+  @apply dark:text-neutral-200 text-neutral-900;
+}
+
+.ant-collapse-borderless > .ant-collapse-item {
+  @apply border-neutral-400/20;
+}
+
+.ant-checkbox-wrapper {
+  @apply dark:text-neutral-200 text-neutral-900 font-display;
+}
+
+.ant-checkbox .ant-checkbox-inner {
+  @apply dark:bg-white/20 dark:border-neutral-400/20;
+}
+
+.ant-checkbox-checked .ant-checkbox-inner {
+  @apply dark:bg-blue-500 dark:border-neutral-400/20;
+}
+
+.ant-collapse > .ant-collapse-item {
+  @apply dark:border-neutral-400/20;
+}
+
+.ant-collapse {
+  @apply dark:bg-neutral-800 dark:border-neutral-400/30;
+}
+
+.ant-collapse-content {
+  @apply dark:bg-neutral-800 dark:text-neutral-200 dark:border-neutral-400/30;
+}
+
+.ant-popover-inner {
+  @apply dark:bg-neutral-800;
+}
+
+.ant-popconfirm-message {
+  @apply dark:text-neutral-200;
+}
+
+.ant-popconfirm-description {
+  @apply dark:text-neutral-200;
+}
+
+:is(.dark .ant-popover) {
+  --antd-arrow-background-color: #262626;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,6 +36,6 @@ module.exports = {
       },
     },
   },
-  darkMode: "media",
+  darkMode: "class",
   plugins: [require("@tailwindcss/forms")],
 };


### PR DESCRIPTION
Implemented a dark mode fully with TailwindCSS and the help of the `next-themes` npm package that handles toggling, saving preference to local storage, etc.

**Preview:**

![image](https://github.com/cesium/calendarium/assets/80540164/007bc785-7741-4dea-a872-bc1618f0fe6e)

![image](https://github.com/cesium/calendarium/assets/80540164/1400a30b-db64-4cf7-85ab-be19ad8893e1)

![image](https://github.com/cesium/calendarium/assets/80540164/5d704234-e815-494e-b0f5-a5a26876ee99)
