### PR TITLE
fix: scraper doesn't find some subjects

### DIFF
--- a/scraper/modules/course_scraper.py
+++ b/scraper/modules/course_scraper.py
@@ -80,6 +80,11 @@ def course_scraper(driver: WebDriver, course_name: str, subject_codes: list[dict
         1: date_range["minDateStr"],
         2: date_range["maxDateStr"]
     }
+
+    # The dates are hardcoded because some subjects aren't present on the first/last semester week
+    semesters_dates[1] = f"{semesters_dates[1][0:5]}11-15{semesters_dates[1][10:]}"
+    semesters_dates[2] = f"{semesters_dates[2][0:5]}03-15{semesters_dates[2][10:]}"
+
     amount_of_years_pickers = len(driver.find_elements(
         By.NAME, "ctl00$ctl40$g_e84a3962_8ce0_47bf_a5c3_d5f9dd3927ef$ctl00$dataAnoCurricular"))
 

--- a/scraper/modules/subjects_scraper.py
+++ b/scraper/modules/subjects_scraper.py
@@ -144,7 +144,7 @@ def scraper(driver: WebDriver, course_name: str, short_names, master: bool = Fal
 
     endpoint = "licenciaturas-e-mestrados-integrados" if not master else "Mestrados"
     driver.get(
-        f"https://www.uminho.pt/PT/ensino/oferta-educativa/paginas/{endpoint}.aspx")
+        f"https://www.uminho.pt/PT/ensino/oferta-educativa/Cursos-Conferentes-a-Grau/Paginas/{endpoint}.aspx")
 
     # search courses input
     driver.find_element(By.CSS_SELECTOR, "input.form-control") \


### PR DESCRIPTION
The subject "Mecânica Quântica" wasn't being found because on the last week of the semester it wasn't no more present on the official schedule.

To prevent this, the scraping month and day were hard coded to the half of the semester.