### PR TITLE
fix: add `ProjInf` and `IngA` short names manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+venv
+
 # Logs
 logs
 *.log

--- a/scraper/modules/subjects_short_names_scraper.py
+++ b/scraper/modules/subjects_short_names_scraper.py
@@ -32,7 +32,7 @@ manual_subject_names = {
     },
     "11738": {
         "name": "Inglês Académico",
-        "short_name": "IA",
+        "short_name": "IngA",
     },
     "15417": {
         "name": "Introdução à Língua e Cultura Russa",
@@ -69,7 +69,7 @@ manual_subject_names = {
 
     "14602": {
         "name": "Projeto de Informática",
-        "short_name": "PI"
+        "short_name": "ProjInf"
     },
     "14603": {
         "name": "Dissertação",

--- a/scraper/subjects.json
+++ b/scraper/subjects.json
@@ -91,7 +91,7 @@
     "id": 1112,
     "subjectId": 11738,
     "name": "Inglês Académico",
-    "short_name": "IA",
+    "short_name": "IngA",
     "year": 1,
     "semester": 1
   },
@@ -739,7 +739,7 @@
     "id": 511,
     "subjectId": 14602,
     "name": "Projeto de Informática",
-    "short_name": "PI",
+    "short_name": "ProjInf",
     "year": 5,
     "semester": 1
   },

--- a/scraper/subjects_short_names.json
+++ b/scraper/subjects_short_names.json
@@ -333,7 +333,7 @@
   },
   "11738": {
     "name": "Inglês Académico",
-    "short_name": "IA"
+    "short_name": "IngA"
   },
   "15417": {
     "name": "Introdução à Língua e Cultura Russa",
@@ -369,7 +369,7 @@
   },
   "14602": {
     "name": "Projeto de Informática",
-    "short_name": "PI"
+    "short_name": "ProjInf"
   },
   "14603": {
     "name": "Dissertação",


### PR DESCRIPTION
Adding this to the scraper code makes sure that the problem of having two pairs of equal short names (PI - Programação Imperativa, PI - Projeto Informática, IA - Inteligência Artificial, IA - Inglês Académico) never happens again, even if we clean the scraper "cache", i.e. the `subjects_short_names.json` and `subjects.json` files.