### PR TITLE
Update shifts.json: MNoL PL7 room

### DIFF
--- a/data/shifts.json
+++ b/data/shifts.json
@@ -2093,7 +2093,7 @@
     "theoretical": false,
     "shift": "PL7",
     "building": "CP2",
-    "room": "2.10",
+    "room": "1.10",
     "day": 4,
     "start": "11:00",
     "end": "13:00",


### PR DESCRIPTION
Alteração da sala de MNoL turno PL7.

Segue-se o email enviado pela professora:

```
Caros alunos,

Gostaria de informar que houve uma modificação na sala de aula para o turno PL7 (6ª feira das 11h às 13h). A partir de agora, as aulas serão realizadas no Edifício 2, Sala 1.10.

Esta mudança é válida para todo o semestre.

Atenciosamente,

Elsa Silva
```