### PR TITLE
fix: patch `undefined` error

### DIFF
--- a/data/shifts.json
+++ b/data/shifts.json
@@ -1949,7 +1949,7 @@
     "theoretical": true,
     "shift": "T1",
     "building": "CP1",
-    "room": "0.20",
+    "room": "0.08",
     "day": 1,
     "start": "09:00",
     "end": "11:00",
@@ -3468,18 +3468,6 @@
     "filterId": 321
   },
   {
-    "id": 14317,
-    "title": "Processamento de Linguagens",
-    "theoretical": false,
-    "shift": "PL3",
-    "building": "7",
-    "room": "0.08",
-    "day": 0,
-    "start": "14:00",
-    "end": "16:00",
-    "filterId": 324
-  },
-  {
     "id": 14319,
     "title": "Engenharia Web",
     "theoretical": true,
@@ -3492,6 +3480,18 @@
     "filterId": 327
   },
   {
+    "id": 14317,
+    "title": "Processamento de Linguagens",
+    "theoretical": false,
+    "shift": "PL3",
+    "building": "7",
+    "room": "0.08",
+    "day": 0,
+    "start": "14:00",
+    "end": "16:00",
+    "filterId": 324
+  },
+  {
     "id": 14318,
     "title": "Aprendizagem e Decisão Inteligentes",
     "theoretical": false,
@@ -3502,6 +3502,18 @@
     "start": "14:00",
     "end": "16:00",
     "filterId": 321
+  },
+  {
+    "id": 14319,
+    "title": "Engenharia Web",
+    "theoretical": true,
+    "shift": "T1",
+    "building": "CP2",
+    "room": "0.05",
+    "day": 0,
+    "start": "14:00",
+    "end": "16:00",
+    "filterId": 327
   },
   {
     "id": 14321,
@@ -4648,8 +4660,8 @@
     "title": "Redes Definidas por Software",
     "theoretical": true,
     "shift": "T1",
-    "building": "CP1",
-    "room": "0.17",
+    "building": "7",
+    "room": "1.09",
     "day": 4,
     "start": "13:00",
     "end": "14:00",
@@ -4768,8 +4780,8 @@
     "title": "Redes Definidas por Software",
     "theoretical": false,
     "shift": "TP1",
-    "building": "CP1",
-    "room": "0.17",
+    "building": "7",
+    "room": "1.09",
     "day": 4,
     "start": "14:00",
     "end": "16:00",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,9 +13,8 @@ import Layout from "../components/Layout";
 import EventModal from "../components/EventModal";
 import styles from "../styles/events.module.css";
 import { IEventDTO } from "../dtos";
-import { reduceOpacity, defaultColors } from "../utils";
+import { reduceOpacity, defaultColors, mergeColors } from "../utils";
 import { SubjectColor } from "../types";
-import { merge } from "antd/es/theme/util/statistic";
 
 const localizer = momentLocalizer(moment);
 
@@ -175,14 +174,6 @@ export default function Home({ filters }) {
     }
 
     return color;
-  }
-
-  function mergeColors(colors: string[]) {
-    let merged = [...colors];
-    for (let i = 0; i < defaultColors.length; i++) {
-      if (merged[i] === undefined) merged[i] = defaultColors[i];
-    }
-    return merged;
   }
 
   function saveTheme() {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -167,7 +167,7 @@ export default function Home({ filters }) {
     else if (theme === "Classic") color = "white";
     else if (theme === "Custom") {
       if (customType === "Year") {
-        opacity ? (color = colors[event.groupId]) : (color = "white");
+        opacity ? (color = colors[event.groupId] ?? defaultColors[event.groupId]) : (color = "white");
       } else if (customType === "Subject") {
         opacity ? (color = getSubjectColor(event)) : (color = "white");
       }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,6 +15,7 @@ import styles from "../styles/events.module.css";
 import { IEventDTO } from "../dtos";
 import { reduceOpacity, defaultColors } from "../utils";
 import { SubjectColor } from "../types";
+import { merge } from "antd/es/theme/util/statistic";
 
 const localizer = momentLocalizer(moment);
 
@@ -176,6 +177,14 @@ export default function Home({ filters }) {
     return color;
   }
 
+  function mergeColors(colors: string[]) {
+    let merged = [...colors];
+    for (let i = 0; i < defaultColors.length; i++) {
+      if (merged[i] === undefined) merged[i] = defaultColors[i];
+    }
+    return merged;
+  }
+
   function saveTheme() {
     let theme = localStorage.getItem("theme");
     const colors = localStorage.getItem("colors");
@@ -184,6 +193,10 @@ export default function Home({ filters }) {
     const subjectColors: SubjectColor[] =
       JSON.parse(localStorage.getItem("subjectColors")) ?? [];
 
+    // error proof checks
+    colors &&
+      colors.split(",").length !== defaultColors.length &&
+      localStorage.setItem("colors", mergeColors(colors.split(",")).join(","));
     !theme && localStorage.setItem("theme", "Modern");
     !customType && localStorage.setItem("customType", "Subject");
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -148,8 +148,8 @@ export default function Home({ filters }) {
     else if (theme === "Custom") {
       if (customType === "Year") {
         opacity
-          ? (color = reduceOpacity(colors[event.groupId]))
-          : (color = colors[event.groupId]);
+          ? (color = reduceOpacity(colors[event.groupId] ?? defaultColors[event.groupId]))
+          : (color = colors[event.groupId] ?? defaultColors[event.groupId]);
       } else if (customType === "Subject") {
         opacity
           ? (color = reduceOpacity(getSubjectColor(event)))

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -8,15 +8,12 @@ import { Calendar, momentLocalizer } from "react-big-calendar";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 
 import moment from "moment";
-import path from "path";
-import fsPromises from "fs/promises";
 
 import ShiftModal from "../components/ShiftModal";
 import Layout from "../components/Layout";
 import { IFilterDTO, IShiftDTO } from "../dtos";
-import { reduceOpacity } from "../utils";
+import { reduceOpacity, defaultColors, mergeColors } from "../utils";
 import { SubjectColor } from "../types";
-import { defaultColors } from "../utils";
 
 import styles from "../styles/schedule.module.css";
 
@@ -124,6 +121,10 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
     const subjectColors: SubjectColor[] =
       JSON.parse(localStorage.getItem("subjectColors")) ?? [];
 
+    // error proof checks
+    colors &&
+      colors.split(",").length !== defaultColors.length &&
+      localStorage.setItem("colors", mergeColors(colors.split(",")).join(","));
     !theme && localStorage.setItem("theme", "Modern");
     !customType && localStorage.setItem("customType", "Subject");
 

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -83,8 +83,8 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
     else if (colorTheme === "Custom") {
       if (customType === "Year") {
         opacity
-          ? (color = reduceOpacity(colors[String(event.filterId)[0]]))
-          : (color = colors[String(event.filterId)[0]]);
+          ? (color = reduceOpacity(colors[String(event.filterId)[0]] ?? getDefaultColor(event)))
+          : (color = colors[String(event.filterId)[0]] ?? getDefaultColor(event));
       } else if (customType === "Subject") {
         opacity
           ? (color = reduceOpacity(getSubjectColor(event)))

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -103,7 +103,7 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
     else if (colorTheme === "Custom") {
       if (customType === "Year") {
         opacity
-          ? (color = colors[String(event.filterId)[0]])
+          ? (color = colors[String(event.filterId)[0]] ?? getDefaultColor(event))
           : (color = "white");
       } else if (customType === "Subject") {
         opacity ? (color = getSubjectColor(event)) : (color = "white");

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -119,3 +119,11 @@ export async function getEvents(
     ); // filter out invalid/incomplete events
   }
 }
+
+export function mergeColors(colors: string[]) {
+  let merged = [...colors];
+  for (let i = 0; i < defaultColors.length; i++) {
+    if (merged[i] === undefined) merged[i] = defaultColors[i];
+  }
+  return merged;
+}


### PR DESCRIPTION
Finally was able to recreate a weird bug that had been happening to some people. The bug consisted on the app crashing when reaching a certain month. After recreating the `localStorage` of a user with this problem I was able to recreate the bug on my machine. After exploring and messing with the different parameters I finally got it:

The colors defined for each course year + the colors defined for special events (like UMinho, CeSIUM, SEI, etc) are stored in `localStorage`, when a user tries to change the app theme based on "Year". From this point onward, the app will prioritize the values in `localStorage`, instead of the default values, as long as the "Year" option for the custom theme is selected. Recently a new special event color was added to Calendarium, the Bugsbyte color, which means this color array grew, however the `localStorage` values people had stayed the same, this meant that every time the app tried to render the Bugsbyte event, and thus get its color, the color would not be found in `localStorage` resulting in an `undefined` value that crashed the system.

I patched this by adding a condition in the `saveTheme()` function, that checks for differences in the length of the `localStorage` colors and the default colors, merging the values together if true so that new colors are added.
