### PR TITLE
feat: improve today button in toolbar for better understanding

### DIFF
--- a/components/CustomToolbar/CustomToolbar.tsx
+++ b/components/CustomToolbar/CustomToolbar.tsx
@@ -7,7 +7,7 @@ import { useWindowSize } from "../../utils";
 const MobileToolbar = ({ view, onView }) => {
   return (
     <Menu as="div" className="relative inline-block">
-      <Menu.Button>
+      <Menu.Button className="h-[2.1rem]">
         {view === "day" ? (
           <i className="bi bi-calendar3-event"></i>
         ) : view === "week" ? (
@@ -33,7 +33,9 @@ const MobileToolbar = ({ view, onView }) => {
                   type="button"
                   title="Day"
                   // don't use condition && "result" -> className can't be a boolean
-                  className={view === "day" ? "rbc-active" : undefined}
+                  className={`${
+                    view === "day" ? "rbc-active" : undefined
+                  } h-[2.1rem]`}
                   onClick={() => onView("day")}
                 >
                   <i className="bi bi-calendar3-event"></i> Day
@@ -46,7 +48,9 @@ const MobileToolbar = ({ view, onView }) => {
                   type="button"
                   title="Week"
                   // don't use condition && "result" -> className can't be a boolean
-                  className={view === "week" ? "rbc-active" : undefined}
+                  className={`${
+                    view === "week" ? "rbc-active" : undefined
+                  } h-[2.1rem]`}
                   onClick={() => onView("week")}
                 >
                   <i className="bi bi-calendar3-week"></i> Week
@@ -59,7 +63,9 @@ const MobileToolbar = ({ view, onView }) => {
                   type="button"
                   title="Month"
                   // don't use condition && "result" -> className can't be a boolean
-                  className={view === "month" ? "rbc-active" : undefined}
+                  className={`${
+                    view === "month" ? "rbc-active" : undefined
+                  } h-[2.1rem]`}
                   onClick={() => onView("month")}
                 >
                   <i className="bi bi-calendar3"></i> Month
@@ -80,7 +86,7 @@ const DesktopToolbar = ({ view, onView }) => {
         type="button"
         title="Day"
         // don't use condition && "result" -> className can't be a boolean
-        className={view === "day" ? "rbc-active" : undefined}
+        className={`${view === "day" ? "rbc-active" : undefined} h-[2.1rem]`}
         onClick={() => onView("day")}
       >
         <i className="bi bi-calendar3-event"></i>
@@ -89,7 +95,7 @@ const DesktopToolbar = ({ view, onView }) => {
         type="button"
         title="Week"
         // don't use condition && "result" -> className can't be a boolean
-        className={view === "week" ? "rbc-active" : undefined}
+        className={`${view === "week" ? "rbc-active" : undefined} h-[2.1rem]`}
         onClick={() => onView("week")}
       >
         <i className="bi bi-calendar3-week"></i>
@@ -98,7 +104,7 @@ const DesktopToolbar = ({ view, onView }) => {
         type="button"
         title="Month"
         // don't use condition && "result" -> className can't be a boolean
-        className={view === "month" ? "rbc-active" : undefined}
+        className={`${view === "month" ? "rbc-active" : undefined} h-[2.1rem]`}
         onClick={() => onView("month")}
       >
         <i className="bi bi-calendar3"></i>
@@ -107,19 +113,37 @@ const DesktopToolbar = ({ view, onView }) => {
   );
 };
 
-const CustomToolbar = ({ label, onNavigate, view, onView }: ToolbarProps) => {
+const CustomToolbar = ({
+  date,
+  label,
+  onNavigate,
+  view,
+  onView,
+}: ToolbarProps) => {
   const size = useWindowSize();
 
   return (
     <div className="rbc-toolbar">
       <span className="rbc-btn-group">
-        <button type="button" onClick={() => onNavigate(Navigate.TODAY)}>
-          <i className="bi bi-brightness-high-fill"></i>
+        <button
+          className="h-[2.1rem] text-sm"
+          type="button"
+          onClick={() => onNavigate(Navigate.TODAY)}
+        >
+          Today
         </button>
-        <button type="button" onClick={() => onNavigate(Navigate.PREVIOUS)}>
+        <button
+          className="h-[2.1rem]"
+          type="button"
+          onClick={() => onNavigate(Navigate.PREVIOUS)}
+        >
           <i className="bi bi-caret-left-fill"></i>
         </button>
-        <button type="button" onClick={() => onNavigate(Navigate.NEXT)}>
+        <button
+          className="h-[2.1rem]"
+          type="button"
+          onClick={() => onNavigate(Navigate.NEXT)}
+        >
           <i className="bi bi-caret-right-fill"></i>
         </button>
       </span>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,11 +1,21 @@
 import { Html, Head, Main, NextScript } from "next/document";
-import { useTheme } from "next-themes";
-import { useEffect } from "react";
 
 export default function Document() {
   return (
     <Html lang="en" className="dark">
       <Head>
+        {/* Fonts and Icons */}
+        <link
+          rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap"
+          rel="stylesheet"
+        />
+        {/* Web App Related */}
         <link rel="manifest" href="/manifest.webmanifest" />
         <link rel="apple-touch-icon" href="/pwa/ios/512.png"></link>
         {/* Splash Screen configuration for IOS devices */}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,6 +1,3 @@
-@import url("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css");
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Noto+Sans:wght@400;500;600;700&family=Roboto:wght@400;500;600;700&display=swap");
-
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";


### PR DESCRIPTION
Changed the today button in the calendar toolbar so that it reads "Today" instead of the previous sun icon that could be confused for a light/dark mode toggle and was unclear in general. Also moved font and icon imports to Head for improved efficiency.

- **feat: import fonts and icons in head**
- **feat: change today button look**
