### PR TITLE
feat: display 'information not available' message for empty collapses in /schedule

### DIFF
--- a/components/FilterBlock/FilterBlock.tsx
+++ b/components/FilterBlock/FilterBlock.tsx
@@ -203,8 +203,7 @@ const FilterBlock = ({
   }) => {
     return (
       <>
-        {shifts &&
-          shifts.length > 0 &&
+        {shifts && shifts.length > 0 ? (
           shifts.map((item) => (
             <Fragment key={id.toString() + item + "Checkbox"}>
               <div>
@@ -217,7 +216,10 @@ const FilterBlock = ({
                 </Checkbox>
               </div>
             </Fragment>
-          ))}
+          ))
+        ) : (
+          <p className="text-neutral-400">Information not available.</p>
+        )}
       </>
     );
   };
@@ -317,7 +319,7 @@ const FilterBlock = ({
                           >
                             {checkBoxes[index1 * layer2.length + index2] &&
                             checkBoxes[index1 * layer2.length + index2].some(
-                              (item) => item.shifts
+                              (item) => item.shifts && item.shifts.length > 0
                             ) ? (
                               <>
                                 {checkBoxes[
@@ -341,6 +343,12 @@ const FilterBlock = ({
                                   </Fragment>
                                 ))}
                               </>
+                            ) : checkBoxes[
+                                index1 * layer2.length + index2
+                              ].some((item) => item.shifts) ? (
+                              <p className="text-neutral-400">
+                                Information not available.
+                              </p>
                             ) : (
                               <>
                                 <SelectAll


### PR DESCRIPTION
| | |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/c3af2670-33c7-4c71-8e4b-a9f74febf482) | ![image](https://github.com/user-attachments/assets/932a5124-34ca-445d-8593-1cc6c669df8c) |

Contexto: LI4 não tem turnos este ano.
