### PR TITLE
fix: re-add shifts removed by scraper

### DIFF
--- a/data/filters.json
+++ b/data/filters.json
@@ -123,7 +123,7 @@
     "name": "SASE",
     "groupId": 1,
     "semester": 1,
-    "shifts": []
+    "shifts": ["T1"]
   },
   {
     "id": 1119,
@@ -311,7 +311,7 @@
     "name": "LI4",
     "groupId": 3,
     "semester": 1,
-    "shifts": ["T1"]
+    "shifts": ["T1", "OT2", "OT3", "OT4", "OT5"]
   },
   {
     "id": 316,

--- a/data/shifts.json
+++ b/data/shifts.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "",
+    "title": "Sustentabilidade Ambiental, Social e Económica",
+    "theoretical": true,
+    "shift": "T1",
+    "building": "CP1",
+    "room": "1.30",
+    "day": 1,
+    "start": "18:00",
+    "end": "20:00",
+    "filterId": 1118
+  },
+  {
     "id": 14294,
     "title": "Programação Funcional",
     "theoretical": false,


### PR DESCRIPTION
The scraper is having problems adding the LI4 shifts to `filters.json` and is not picking up a shift for "Sustentabilidade Ambiental, Social e Económica". Both these problems were manually fixed in #226 and somewhere else along with other PR. However, every time the scraper runs it removes these manual changes when generating the JSON files, so we have to be aware of that from now on while the problem isn't fixed in the scraper itself.

#235 was merged by @ruilopesm because he didn't know this, so I'm adding the required changes back.
