### PR TITLE
feat: layout improvements

### DIFF
--- a/components/CustomToolbar/CustomToolbar.tsx
+++ b/components/CustomToolbar/CustomToolbar.tsx
@@ -119,20 +119,14 @@ const DesktopToolbar = ({ view, onView }) => {
   );
 };
 
-const CustomToolbar = ({
-  date,
-  label,
-  onNavigate,
-  view,
-  onView,
-}: ToolbarProps) => {
+const CustomToolbar = ({ label, onNavigate, view, onView }: ToolbarProps) => {
   const size = useWindowSize();
 
   return (
-    <div className="rbc-toolbar">
+    <div className="rbc-toolbar px-4 sm:px-6">
       <span className="rbc-btn-group">
         <button
-          className="h-[2.1rem] text-sm"
+          className="flex h-[2.1rem] items-center justify-center text-sm"
           type="button"
           onClick={() => onNavigate(Navigate.TODAY)}
         >

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -43,9 +43,10 @@ const Layout = ({
         filters,
         handleFilters,
         fetchTheme,
+        image,
       }}
     >
-      <div className="text-neutral-900 dark:text-neutral-200 lg:flex">
+      <div className="flex h-dvh flex-col text-neutral-900 dark:text-neutral-200 lg:flex-row">
         <Head>
           {/* Status Bar configuration for Android devices */}
           <meta
@@ -60,7 +61,7 @@ const Layout = ({
         </Head>
         {/* Open/Close Sidebar Button */}
         <button
-          className="absolute left-8 top-8 z-20 flex h-10 w-10 flex-col items-center justify-center rounded-xl bg-white shadow-md ring-1 ring-neutral-100/50 dark:bg-neutral-800/70 dark:ring-neutral-400/20 min-[400px]:h-11 min-[400px]:w-11 sm:h-12 sm:w-12 lg:hidden"
+          className="absolute left-4 top-4 z-20 flex h-10 w-10 flex-col items-center justify-center rounded-xl bg-white shadow-md ring-1 ring-neutral-100/50 dark:bg-neutral-800/70 dark:ring-neutral-400/20 min-[400px]:h-11 min-[400px]:w-11 sm:left-6 sm:top-6 sm:h-12 sm:w-12 lg:hidden"
           onClick={() => setIsOpen(!isOpen)}
         >
           <div
@@ -88,7 +89,7 @@ const Layout = ({
         <Notifications isOpen={isOpen} />
 
         {/* Calendarium Logo */}
-        <div className="px-8 pt-8 lg:hidden">
+        <div className="px-4 pt-4 sm:px-6 sm:pt-6 lg:hidden">
           <div className="mx-auto flex h-10 w-fit cursor-pointer items-center min-[400px]:h-11 sm:h-12">
             <Link href="/">
               <Image
@@ -124,7 +125,7 @@ const Layout = ({
         </div>
 
         {/* Children */}
-        <main className="h-[calc(100dvh-4.9rem)] w-full flex-1 px-8 py-8  lg:ml-96 lg:h-screen">
+        <main className="w-full flex-1 p-4 sm:p-6 lg:ml-96 lg:pb-4">
           {children}
         </main>
       </div>

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -2,11 +2,11 @@ import { useState, ReactNode, useEffect } from "react";
 import Link from "next/link";
 import Sidebar from "../Sidebar";
 import Notifications from "../Notifications";
-import styles from "./layout.module.scss";
 import { useTheme } from "next-themes";
 import Head from "next/head";
 import Image from "next/image";
 import { AppInfoProvider } from "../../contexts/AppInfoProvider";
+import MoreButton from "../MoreButton";
 
 interface ILayoutProps {
   children: ReactNode;
@@ -14,6 +14,7 @@ interface ILayoutProps {
   filters: any;
   handleFilters: any;
   fetchTheme: () => void;
+  handleData?: (_: boolean) => void;
 }
 
 const Layout = ({
@@ -22,6 +23,7 @@ const Layout = ({
   filters,
   handleFilters,
   fetchTheme,
+  handleData,
 }: ILayoutProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const hamburgerLine = `h-1 w-6 my-0.5 rounded-full bg-black transition ease transform duration-300 dark:bg-neutral-200 bg-neutral-900`;
@@ -44,6 +46,7 @@ const Layout = ({
         handleFilters,
         fetchTheme,
         image,
+        handleData,
       }}
     >
       <div className="flex h-dvh flex-col text-neutral-900 dark:text-neutral-200 lg:flex-row">
@@ -61,7 +64,7 @@ const Layout = ({
         </Head>
         {/* Open/Close Sidebar Button */}
         <button
-          className="absolute left-4 top-4 z-20 flex h-10 w-10 flex-col items-center justify-center rounded-xl bg-white shadow-md ring-1 ring-neutral-100/50 dark:bg-neutral-800/70 dark:ring-neutral-400/20 min-[400px]:h-11 min-[400px]:w-11 sm:left-6 sm:top-6 sm:h-12 sm:w-12 lg:hidden"
+          className="absolute left-4 top-4 z-20 flex h-10 w-10 flex-col items-center justify-center rounded-xl bg-white shadow-md ring-1 ring-neutral-100/50 dark:bg-[#212121] dark:ring-neutral-400/20 min-[400px]:h-11 min-[400px]:w-11 sm:left-6 sm:top-6 sm:h-12 sm:w-12 lg:hidden"
           onClick={() => setIsOpen(!isOpen)}
         >
           <div
@@ -108,26 +111,11 @@ const Layout = ({
           <Sidebar isOpen={isOpen} setIsOpen={setIsOpen} />
         </div>
 
-        {/* Feedback Button */}
-        <div
-          className={`fixed bottom-0 right-0 z-20 transform pb-4 pr-4 transition duration-300 lg:translate-y-0 ${
-            !isOpen && "translate-y-full"
-          }`}
-        >
-          <button
-            onClick={() => window.open("https://forms.gle/C2uxuUKqoeqMWfcZ6")}
-            className={styles.buttonBug}
-          >
-            <div>
-              <p>Feedback</p> <i className="bi bi-chat-fill"></i>
-            </div>
-          </button>
-        </div>
+        {/* More Button */}
+        <MoreButton isOpen={isOpen} />
 
         {/* Children */}
-        <main className="w-full flex-1 p-4 sm:p-6 lg:ml-96 lg:pb-4">
-          {children}
-        </main>
+        <main className="w-full flex-1 lg:ml-96">{children}</main>
       </div>
     </AppInfoProvider>
   );

--- a/components/MoreButton/MoreButton.tsx
+++ b/components/MoreButton/MoreButton.tsx
@@ -1,0 +1,74 @@
+import { Fragment } from "react";
+import { Menu, Transition } from "@headlessui/react";
+import { useAppInfo } from "../../contexts/AppInfoProvider";
+
+const MoreButton = ({ isOpen }: { isOpen: boolean }) => {
+  const info = useAppInfo();
+
+  return (
+    <div
+      className={`fixed bottom-0 right-0 z-50 transform pb-4 pr-4 transition duration-300 lg:translate-x-0 lg:translate-y-0 ${
+        !isOpen && "translate-x-full translate-y-full"
+      }`}
+    >
+      <Menu as="div" className="relative inline-block">
+        <Menu.Button className="h-10 w-10 rounded-xl p-2 leading-3 text-neutral-300 shadow-md ring-1 ring-neutral-200/50 transition-all duration-300 hover:text-neutral-900 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500 dark:bg-[#212121] dark:text-neutral-500 dark:ring-neutral-400/20 dark:hover:text-neutral-200">
+          <i className="bi bi-three-dots"></i>
+        </Menu.Button>
+        <Transition
+          as={Fragment}
+          enter="transition ease-out duration-100"
+          enterFrom="transform opacity-0 scale-95"
+          enterTo="transform opacity-100 scale-100"
+          leave="transition ease-in duration-75"
+          leaveFrom="transform opacity-100 scale-100"
+          leaveTo="transform opacity-0 scale-95"
+        >
+          <Menu.Items className="absolute bottom-full right-0 mb-3 origin-bottom-right">
+            <div className="flex w-fit flex-col items-center justify-center overflow-hidden text-nowrap rounded-xl bg-white font-medium shadow-md ring-1 ring-neutral-200/50 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500 dark:bg-[#212121] dark:ring-neutral-400/20">
+              <Menu.Item>
+                {({ active }) => (
+                  <button
+                    onClick={() =>
+                      window.open("https://forms.gle/C2uxuUKqoeqMWfcZ6")
+                    }
+                    className="inline-flex w-full items-center justify-center gap-2 border-b border-neutral-200/20 px-3 py-2 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800/90"
+                  >
+                    <i className="bi bi-chat-fill"></i> Feedback
+                  </button>
+                )}
+              </Menu.Item>
+              <Menu.Item>
+                {({ active }) => (
+                  <button
+                    onClick={() =>
+                      window.open(
+                        info.isEvents
+                          ? "https://docs.google.com/forms/d/e/1FAIpQLSfpk0mJowLtjPdJo99NOVDD5G8IX0UPMWOO6g5ngJ1gZNMsqQ/viewform"
+                          : "https://alunos.uminho.pt/pt/estudantes/paginas/infouteishorarios.aspx"
+                      )
+                    }
+                    className="inline-flex w-full items-center justify-center gap-2 px-3 py-2 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800/90"
+                  >
+                    {info.isEvents ? (
+                      <>
+                        <i className="bi bi-calendar-plus-fill"></i> Add Event
+                      </>
+                    ) : (
+                      <>
+                        <i className="bi bi-box-arrow-up-right" /> Horários
+                        UMinho
+                      </>
+                    )}
+                  </button>
+                )}
+              </Menu.Item>
+            </div>
+          </Menu.Items>
+        </Transition>
+      </Menu>
+    </div>
+  );
+};
+
+export default MoreButton;

--- a/components/MoreButton/MoreButton.tsx
+++ b/components/MoreButton/MoreButton.tsx
@@ -7,12 +7,12 @@ const MoreButton = ({ isOpen }: { isOpen: boolean }) => {
 
   return (
     <div
-      className={`fixed bottom-0 right-0 z-50 transform pb-4 pr-4 transition duration-300 lg:translate-x-0 lg:translate-y-0 ${
+      className={`fixed bottom-0 right-0 z-50 transform p-4 transition duration-300 lg:translate-x-0 lg:translate-y-0 ${
         !isOpen && "translate-x-full translate-y-full"
       }`}
     >
       <Menu as="div" className="relative inline-block">
-        <Menu.Button className="h-10 w-10 rounded-xl p-2 leading-3 text-neutral-300 shadow-md ring-1 ring-neutral-200/50 transition-all duration-300 hover:text-neutral-900 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500 dark:bg-[#212121] dark:text-neutral-500 dark:ring-neutral-400/20 dark:hover:text-neutral-200">
+        <Menu.Button className="size-11 rounded-xl bg-cesium-900 p-2 leading-3 text-neutral-100 shadow-md ring-1 ring-cesium-900/50 transition-all duration-300 hover:bg-[#ed906f] hover:shadow-cesium-900/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cesium-500 dark:ring-cesium-900/20">
           <i className="bi bi-three-dots"></i>
         </Menu.Button>
         <Transition

--- a/components/MoreButton/index.ts
+++ b/components/MoreButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MoreButton";

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -9,7 +9,6 @@ import ClearSelectionButton from "../ClearSelectionButton";
 import NavigationPane from "../NavigationPane";
 import ShareButton from "../ShareButton";
 import { BeforeInstallPromptEvent } from "../../types";
-import { useTheme } from "next-themes";
 import { useAppInfo } from "../../contexts/AppInfoProvider";
 import { ISelectedFilterDTO } from "../../dtos";
 
@@ -24,7 +23,6 @@ const Sidebar = ({ isOpen, setIsOpen }: SidebarProps) => {
   const [checked, setChecked] = useState<number[] | ISelectedFilterDTO[]>([]);
   const [promptInstall, setPromptInstall] =
     useState<BeforeInstallPromptEvent>(null);
-  const [image, setImage] = useState<string>("/calendarium-light.svg");
 
   function clearSelection() {
     setClear(true);
@@ -41,25 +39,19 @@ const Sidebar = ({ isOpen, setIsOpen }: SidebarProps) => {
     return () => window.removeEventListener("transitionend", handler);
   }, []);
 
-  const sidebar = `lg:w-96 lg:block lg:translate-x-0 lg:h-full h-mobile lg:shadow-md lg:border-r dark:border-neutral-400/30 w-full absolute overflow-y-auto overflow-x-hidden lg:overflow-y-auto lg:rounded-r-3xl lg:py-8 pb-8 px-8 bg-white dark:bg-neutral-900 z-10 transition ease transform duration-300`;
+  const sidebar = `lg:w-96 lg:block lg:translate-x-0 lg:h-full h-mobile lg:shadow-md lg:border-r dark:border-neutral-400/30 w-full absolute overflow-y-auto overflow-x-hidden lg:overflow-y-auto lg:rounded-r-3xl p-4 sm:p-6 bg-white dark:bg-neutral-900 z-10 transition ease transform duration-300`;
 
-  const { resolvedTheme } = useTheme();
   const info = useAppInfo();
-
-  useEffect(() => {
-    setImage(
-      resolvedTheme === "dark"
-        ? "/calendarium-dark.svg"
-        : "/calendarium-light.svg"
-    );
-  }, [resolvedTheme]);
 
   return (
     <nav
       className={`${sidebar} ${isOpen ? "block" : "-translate-x-full"}`}
       style={{ direction: "rtl" }}
     >
-      <div className="grid-cols-1 space-y-6" style={{ direction: "ltr" }}>
+      <div
+        className="flex flex-col gap-4 sm:gap-6"
+        style={{ direction: "ltr" }}
+      >
         {/* Calendarium Logo (only shows on large screens) */}
         <div className="hidden lg:block">
           <div
@@ -70,7 +62,7 @@ const Sidebar = ({ isOpen, setIsOpen }: SidebarProps) => {
                 className="h-[46px] w-auto"
                 width={0}
                 height={0}
-                src={image}
+                src={info.image}
                 alt="Calendarium Logo"
               />
             </Link>
@@ -80,8 +72,8 @@ const Sidebar = ({ isOpen, setIsOpen }: SidebarProps) => {
         {/* Page Links */}
         <NavigationPane />
 
-        <div className="flex space-x-4">
-          <div className="flex space-x-4">
+        <div className="flex gap-3 sm:gap-4">
+          <div className="flex gap-3 sm:gap-4">
             {/* Settings Button */}
             <button
               onClick={() => setIsSettings(!isSettings)}

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -23,10 +23,25 @@ const Sidebar = ({ isOpen, setIsOpen }: SidebarProps) => {
   const [checked, setChecked] = useState<number[] | ISelectedFilterDTO[]>([]);
   const [promptInstall, setPromptInstall] =
     useState<BeforeInstallPromptEvent>(null);
+  const [animateRefresh, setAnimateRefresh] = useState<boolean>(false);
 
   function clearSelection() {
     setClear(true);
     setTimeout(() => setClear(false), 300);
+  }
+
+  function refresh() {
+    const lastUpdate: Date =
+      new Date(localStorage.getItem("lastUpdateEvents")) || new Date(); // current date if lastUpdate is null
+    const now: Date = new Date();
+    const diff: number = now.getTime() - lastUpdate.getTime(); // difference in milliseconds
+    const diffMin: number = diff / (1000 * 60); // difference in minutes
+    if (diffMin >= 1) info.handleData(true); // only fetch data if last update was more than 1 minute ago
+    setAnimateRefresh(true);
+    setTimeout(() => {
+      setAnimateRefresh(false);
+      setIsOpen(false);
+    }, 1000);
   }
 
   useEffect(() => {
@@ -94,6 +109,16 @@ const Sidebar = ({ isOpen, setIsOpen }: SidebarProps) => {
             />
             {/* Share Button */}
             <ShareButton setChecked={setChecked} />
+            <button
+              className="h-10 w-10 rounded-xl p-2 leading-3 text-neutral-300 shadow-md ring-1 ring-neutral-200/50 transition-all duration-300 hover:text-neutral-900 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500 dark:bg-neutral-800/70 dark:text-neutral-500 dark:ring-neutral-400/20 dark:hover:text-neutral-200"
+              onClick={refresh}
+              title="Refresh event data"
+              data-umami-event="sync-button"
+            >
+              <div className={animateRefresh ? "animate-spin" : ""}>
+                <i className="bi bi-arrow-repeat" />
+              </div>
+            </button>
           </div>
           {/* Export button */}
           <ExportButton />

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -107,18 +107,21 @@ const Sidebar = ({ isOpen, setIsOpen }: SidebarProps) => {
               isSettings={isSettings}
               clearSelection={clearSelection}
             />
+            {/* Refresh Data Button */}
+            {info.isEvents && (
+              <button
+                className="h-10 w-10 rounded-xl p-2 leading-3 text-neutral-300 shadow-md ring-1 ring-neutral-200/50 transition-all duration-300 hover:text-neutral-900 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500 dark:bg-neutral-800/70 dark:text-neutral-500 dark:ring-neutral-400/20 dark:hover:text-neutral-200"
+                onClick={refresh}
+                title="Refresh event data"
+                data-umami-event="sync-button"
+              >
+                <div className={animateRefresh ? "animate-spin" : ""}>
+                  <i className="bi bi-arrow-repeat" />
+                </div>
+              </button>
+            )}
             {/* Share Button */}
             <ShareButton setChecked={setChecked} />
-            <button
-              className="h-10 w-10 rounded-xl p-2 leading-3 text-neutral-300 shadow-md ring-1 ring-neutral-200/50 transition-all duration-300 hover:text-neutral-900 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500 dark:bg-neutral-800/70 dark:text-neutral-500 dark:ring-neutral-400/20 dark:hover:text-neutral-200"
-              onClick={refresh}
-              title="Refresh event data"
-              data-umami-event="sync-button"
-            >
-              <div className={animateRefresh ? "animate-spin" : ""}>
-                <i className="bi bi-arrow-repeat" />
-              </div>
-            </button>
           </div>
           {/* Export button */}
           <ExportButton />

--- a/contexts/AppInfoProvider.tsx
+++ b/contexts/AppInfoProvider.tsx
@@ -6,6 +6,7 @@ interface AppInfoContextData {
   filters: number[] | IFilterDTO[];
   handleFilters: (filters: number[] | ISelectedFilterDTO[]) => void;
   fetchTheme: () => void;
+  image: string;
 }
 
 const AppContext = createContext<AppInfoContextData | undefined>(undefined);

--- a/contexts/AppInfoProvider.tsx
+++ b/contexts/AppInfoProvider.tsx
@@ -7,6 +7,7 @@ interface AppInfoContextData {
   handleFilters: (filters: number[] | ISelectedFilterDTO[]) => void;
   fetchTheme: () => void;
   image: string;
+  handleData: (_: boolean) => void;
 }
 
 const AppContext = createContext<AppInfoContextData | undefined>(undefined);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -153,12 +153,12 @@ export default function Home({ filters }) {
       fetchTheme={fetchTheme}
       handleData={handleData}
     >
+      <Head>
+        <title>Events | Calendarium</title>
+        <meta name="description" content="Your exams, due dates and more." />
+        <link rel="icon" href="/favicon-calendarium.ico" />
+      </Head>
       <div className="h-full pt-4 sm:pt-6">
-        <Head>
-          <title>Events | Calendarium</title>
-          <meta name="description" content="Your exams, due dates and more." />
-          <link rel="icon" href="/favicon-calendarium.ico" />
-        </Head>
         <Calendar
           className={styles.calendar}
           localizer={localizer}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -151,13 +151,14 @@ export default function Home({ filters }) {
       filters={filters}
       handleFilters={handleFilters}
       fetchTheme={fetchTheme}
+      handleData={handleData}
     >
-      <Head>
-        <title>Events | Calendarium</title>
-        <meta name="description" content="Your exams, due dates and more." />
-        <link rel="icon" href="/favicon-calendarium.ico" />
-      </Head>
-      <div id="events" className="h-full">
+      <div className="h-full pt-4 sm:pt-6">
+        <Head>
+          <title>Events | Calendarium</title>
+          <meta name="description" content="Your exams, due dates and more." />
+          <link rel="icon" href="/favicon-calendarium.ico" />
+        </Head>
         <Calendar
           className={styles.calendar}
           localizer={localizer}
@@ -183,36 +184,14 @@ export default function Home({ filters }) {
             toolbar: CustomToolbar,
           }}
         />
-
-        <footer className="mt-2 font-display text-sm">
-          <button
-            className="transition-colors hover:text-blue-500"
-            onClick={() => handleData(true)}
-            title="Sync event data (updates every hour)"
-            data-umami-event="sync-button"
-          >
-            <i className="bi bi-arrow-repeat" />
-          </button>
-          {" · "}
-          <span className="font-medium">Something missing?</span> Help us{" "}
-          <a
-            href="https://docs.google.com/forms/d/e/1FAIpQLSfpk0mJowLtjPdJo99NOVDD5G8IX0UPMWOO6g5ngJ1gZNMsqQ/viewform"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="cursor-pointer text-blue-500 hover:underline"
-            data-umami-event="event-missing-button"
-          >
-            add it
-          </a>
-        </footer>
+        {selectedEvent && (
+          <EventModal
+            selectedEvent={selectedEvent}
+            setInspectEvent={setInspectEvent}
+            inspectEvent={inspectEvent}
+          />
+        )}
       </div>
-      {selectedEvent && (
-        <EventModal
-          selectedEvent={selectedEvent}
-          setInspectEvent={setInspectEvent}
-          inspectEvent={inspectEvent}
-        />
-      )}
     </Layout>
   );
 }

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -118,10 +118,6 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
   const maxDate = new Date();
   maxDate.setHours(20, 0, 0);
 
-  // RELATED TO APPEARANCE
-
-  const { resolvedTheme } = useTheme();
-
   return (
     <Layout
       isEvents={false}
@@ -129,12 +125,12 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
       handleFilters={handleFilters}
       fetchTheme={fetchTheme}
     >
-      <Head>
-        <title>Schedule | Calendarium</title>
-        <meta name="description" content="Your weekly schedule." />
-        <link rel="icon" href="/favicon-calendarium.ico" />
-      </Head>
-      <div id="schedule" className="h-full">
+      <div className="h-full pt-4 sm:pt-6 md:pt-0">
+        <Head>
+          <title>Schedule | Calendarium</title>
+          <meta name="description" content="Your weekly schedule." />
+          <link rel="icon" href="/favicon-calendarium.ico" />
+        </Head>
         <Calendar
           toolbar={false}
           localizer={localizer}
@@ -147,13 +143,8 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
           max={maxDate}
           eventPropGetter={(event) => {
             const newStyle = {
-              border:
-                "2px solid " + (resolvedTheme === "dark" ? "#171717" : "white"),
               backgroundColor: getBgColor(event),
               color: getTextColor(event),
-              fontWeight: "500",
-              padding: "0.5rem",
-              borderRadius: "12px",
             };
 
             return { style: newStyle };
@@ -163,25 +154,13 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
           events={events}
           className={styles.schedule}
         />
-
-        <footer className="mt-2 font-display text-sm">
-          <span className="font-medium">Source:</span>{" "}
-          <a
-            href="https://alunos.uminho.pt/pt/estudantes/paginas/infouteishorarios.aspx"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="cursor-pointer hover:text-blue-500 hover:underline"
-          >
-            Horários UMinho <i className="bi bi-box-arrow-up-right" />
-          </a>
-        </footer>
+        <ShiftModal
+          selectedShift={selectedShift}
+          setInspectShift={setInspectShift}
+          inspectShift={inspectShift}
+          shifts={shifts}
+        />
       </div>
-      <ShiftModal
-        selectedShift={selectedShift}
-        setInspectShift={setInspectShift}
-        inspectShift={inspectShift}
-        shifts={shifts}
-      />
     </Layout>
   );
 }

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -125,12 +125,12 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
       handleFilters={handleFilters}
       fetchTheme={fetchTheme}
     >
+      <Head>
+        <title>Schedule | Calendarium</title>
+        <meta name="description" content="Your weekly schedule." />
+        <link rel="icon" href="/favicon-calendarium.ico" />
+      </Head>
       <div className="h-full pt-4 sm:pt-6 md:pt-0">
-        <Head>
-          <title>Schedule | Calendarium</title>
-          <meta name="description" content="Your weekly schedule." />
-          <link rel="icon" href="/favicon-calendarium.ico" />
-        </Head>
         <Calendar
           toolbar={false}
           localizer={localizer}

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -165,7 +165,7 @@ export default function Schedule({ filters, shifts }: ISchedulesProps) {
         />
 
         <footer className="mt-2 font-display text-sm">
-          <b>Source:</b>{" "}
+          <span className="font-medium">Source:</span>{" "}
           <a
             href="https://alunos.uminho.pt/pt/estudantes/paginas/infouteishorarios.aspx"
             target="_blank"

--- a/styles/events.module.css
+++ b/styles/events.module.css
@@ -10,6 +10,5 @@
 .calendar {
   z-index: 0;
   width: 100%;
-  height: calc(100% - 1.5rem);
   font-family: Inter;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -96,13 +96,14 @@ a {
   outline: none;
 }
 
-.rbc-calendar .rbc-event:hover {
+/* .rbc-calendar .rbc-event:hover {
   opacity: 0.85;
-}
+} */
 
 .rbc-calendar .rbc-toolbar {
   flex-wrap: nowrap;
   font-weight: 500;
+  @apply mb-4 sm:mb-6;
 }
 
 @media (max-width: 767px) {
@@ -113,9 +114,9 @@ a {
 
 .rbc-calendar .rbc-month-view {
   overflow: hidden;
-  border: 1px solid rgb(203 213 225);
-  @apply dark:border-neutral-400/20;
-  border-radius: 8px;
+  border-top: 1px solid rgb(203 213 225);
+  @apply border-x-0 border-b-0 dark:border-t-neutral-400/20;
+  border-radius: 0px;
 }
 
 .rbc-calendar .rbc-toolbar .rbc-toolbar-label {
@@ -233,13 +234,13 @@ a {
   @apply dark:border-neutral-400/20;
 }
 
-.rbc-calendar .rbc-row-segment .rbc-event {
-  width: calc(100% - 0.5rem);
+.rbc-calendar .rbc-event {
+  width: calc(100% - 0.2rem);
   margin: auto;
-  margin-bottom: 0.25rem;
-  font-weight: 500;
+  margin-bottom: 0.1rem;
+  font-weight: 400;
   border: none;
-  border-radius: 8px;
+  @apply rounded-md text-xs sm:text-sm sm:font-medium;
 }
 
 /* shows a 'today' background color in month view */
@@ -261,14 +262,7 @@ a {
 }
 
 .rbc-calendar .rbc-events-container .rbc-event {
-  margin: auto;
-  font-weight: 500;
-  border: none;
-  border-radius: 10px;
-}
-
-.rbc-calendar .rbc-events-container .rbc-event-content {
-  margin-top: 5px;
+  @apply rounded-lg border-[3px] border-white p-2 transition-opacity hover:opacity-90 dark:border-neutral-900;
 }
 
 .rbc-calendar .rbc-time-content > * + * > * {
@@ -329,8 +323,7 @@ a {
 .rbc-calendar .rbc-time-view {
   overflow: hidden;
   border: 1px solid rgb(203 213 225);
-  @apply dark:border-neutral-400/20;
-  border-radius: 8px;
+  @apply border-x-0 border-b-0 dark:border-t-neutral-400/20 md:border-t-0;
 }
 
 .rbc-calendar .rbc-label {

--- a/styles/schedule.module.css
+++ b/styles/schedule.module.css
@@ -6,6 +6,5 @@
 .schedule {
   z-index: 0;
   width: 100%;
-  height: calc(100% - 1.5rem);
   font-family: Inter;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
     },
     extend: {
       spacing: {
-        mobile: "calc(100dvh - 5.2rem)",
+        mobile: "calc(100dvh - 3.5rem)",
       },
       colors: {
         cesium: {


### PR DESCRIPTION
Major improvements to overall layout, stretching the calendar component to reach the corners of the screen and use the most screen real estate as possible, both on desktop and mobile, while also reducing font-size for better readability:

| Events | Schedule |
| - | - |
| ![Screen Shot 2025-01-08 at 02 23 26](https://github.com/user-attachments/assets/6c8c09b7-2035-45ed-a0de-0de9c2cf0297) | ![Screen Shot 2025-01-08 at 02 23 37](https://github.com/user-attachments/assets/a94c1f62-0094-4fc9-a62b-32939ca53b3d) |
| ![Screen Shot 2025-01-08 at 02 25 25](https://github.com/user-attachments/assets/1e47074c-1a42-4352-a861-ead700c21c4a) | ![Screen Shot 2025-01-08 at 02 25 29](https://github.com/user-attachments/assets/126723c3-8f77-4dcc-bbb5-e56d8f429cbf) |

The missing events form link and the "horários uminho" link were moved from the previous location under the calendar component to a new `MoreButton` component that encapsulates the Feedback button and the missing events form (now "Add Event") or the "horários uminho" link, depending on the page:

| Events | Schedule |
| - | - |
| ![image](https://github.com/user-attachments/assets/abd3ed89-eda0-4ad1-968f-6ddb970acea3) | ![image](https://github.com/user-attachments/assets/11b5c3ea-1779-4947-a063-1179d7f26bdc) |

The refresh button also moved from under the calendar to the sidebar:

![image](https://github.com/user-attachments/assets/479d45c5-4015-416b-90d8-42f99ac11cf5)

