### PR TITLE
refactor: apply recursion to `FilterBlock`

### DIFF
--- a/components/CalendarExportModal/CalendarExportModal.tsx
+++ b/components/CalendarExportModal/CalendarExportModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 
 import { Collapse } from "antd";
 
-import { IFilterDTO } from "../../dtos";
+import { IFilterDTO, ISelectedFilterDTO } from "../../dtos";
 import { useAppInfo } from "../../contexts/AppInfoProvider";
 
 type CalendarExportModalProps = {
@@ -27,7 +27,10 @@ const CalendarExportModal = ({
       const validEvents = checkedEvents.filter((id) =>
         filters.find((f) => f.id === id)
       );
-      localStorage.setItem("checked", JSON.stringify(validEvents));
+      localStorage.setItem(
+        "checked",
+        JSON.stringify(validEvents.map((id) => ({ id })))
+      );
 
       return validEvents;
     }
@@ -53,9 +56,10 @@ const CalendarExportModal = ({
     var query: string = "";
     if (info.isEvents) {
       // fecth checked events from localStorage
-      const checkedEvents: number[] = JSON.parse(
-        localStorage.getItem("checked")
+      const checkedEventsData: ISelectedFilterDTO[] = JSON.parse(
+        localStorage.getItem("checked") ?? "[]"
       );
+      const checkedEvents: number[] = checkedEventsData.map((f) => f.id);
 
       // if there are no checked events, return empty string (empty URL => warning message on modal)
       if (!checkedEvents || checkedEvents.length === 0) return "";

--- a/components/CalendarExportModal/CalendarExportModal.tsx
+++ b/components/CalendarExportModal/CalendarExportModal.tsx
@@ -29,7 +29,7 @@ const CalendarExportModal = ({
       );
       localStorage.setItem(
         "checked",
-        JSON.stringify(validEvents.map((id) => ({ id })))
+        JSON.stringify(validEvents.map((id) => id))
       );
 
       return validEvents;
@@ -56,10 +56,8 @@ const CalendarExportModal = ({
     var query: string = "";
     if (info.isEvents) {
       // fecth checked events from localStorage
-      const checkedEventsData: ISelectedFilterDTO[] = JSON.parse(
-        localStorage.getItem("checked") ?? "[]"
-      );
-      const checkedEvents: number[] = checkedEventsData.map((f) => f.id);
+      const checkedEvents: number[] =
+        JSON.parse(localStorage.getItem("checked")) ?? [];
 
       // if there are no checked events, return empty string (empty URL => warning message on modal)
       if (!checkedEvents || checkedEvents.length === 0) return "";

--- a/components/EventFilters/EventFilters.tsx
+++ b/components/EventFilters/EventFilters.tsx
@@ -1,16 +1,17 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import "antd/dist/reset.css";
 
 import FilterBlock from "../FilterBlock";
 
-import { CheckBoxProps } from "../../types";
+import { CheckBoxProps, Layer } from "../../types";
 import { IFilterDTO, ISelectedFilterDTO } from "../../dtos";
 import { useAppInfo } from "../../contexts/AppInfoProvider";
+import * as mei_perfis from "../../data/mei_perfis";
 
 type EventFiltersProps = {
   clearEvents: boolean;
-  checked: number[] | ISelectedFilterDTO[];
-  setChecked: (obj: number[] | ISelectedFilterDTO[]) => void;
+  checked: ISelectedFilterDTO[];
+  setChecked: (obj: ISelectedFilterDTO[]) => void;
 };
 
 const EventFilters = ({
@@ -23,18 +24,13 @@ const EventFilters = ({
   const handleFilters = info.handleFilters;
 
   useEffect(() => {
-    const stored: number[] = JSON.parse(localStorage.getItem("checked")) ?? [];
-    setChecked(stored);
-    handleFilters(stored);
+    const storedFilters: ISelectedFilterDTO[] =
+      JSON.parse(localStorage.getItem("checked")) ?? [];
+    setChecked(storedFilters);
+    handleFilters(storedFilters);
   }, [setChecked, handleFilters]);
 
   let event: IFilterDTO[][] = [];
-
-  const mei = ["4ᵗʰ year", "5ᵗʰ year"];
-
-  const lei = ["1ˢᵗ year", "2ⁿᵈ year", "3ʳᵈ year"];
-
-  const semesters = ["1ˢᵗ semester", "2ⁿᵈ semester"];
 
   event[0] = filters.filter((f) => f.groupId === 1 && f.semester === 1); // 1st year 1st semester
   event[1] = filters.filter((f) => f.groupId === 1 && f.semester === 2); // 1st year 2nd semester
@@ -76,27 +72,163 @@ const EventFilters = ({
     clearEvents && clearSelection();
   }, [clearEvents, clearSelection]);
 
+  const [activePanels, setActivePanels] = useState<{
+    [key: string]: string;
+  }>({});
+
+  const lei: Layer[] = [
+    {
+      title: "1ˢᵗ year",
+      sublayers: [
+        {
+          title: "1ˢᵗ semester",
+          checkboxes: getCheckBoxes()[0].slice(0, 5),
+          sublayers: [
+            {
+              title: "Opção UMinho",
+              checkboxes: getCheckBoxes()[0].slice(5),
+            },
+          ],
+        },
+        {
+          title: "2ⁿᵈ semester",
+          checkboxes: getCheckBoxes()[1],
+        },
+      ],
+    },
+    {
+      title: "2ⁿᵈ year",
+      sublayers: [
+        {
+          title: "1ˢᵗ semester",
+          checkboxes: getCheckBoxes()[2],
+        },
+        {
+          title: "2ⁿᵈ semester",
+          checkboxes: getCheckBoxes()[3],
+        },
+      ],
+    },
+    {
+      title: "3ʳᵈ year",
+      sublayers: [
+        {
+          title: "1ˢᵗ semester",
+          checkboxes: getCheckBoxes()[4],
+        },
+        {
+          title: "2ⁿᵈ semester",
+          checkboxes: getCheckBoxes()[5],
+        },
+      ],
+    },
+  ];
+
+  const mei: Layer[] = [
+    {
+      title: "4ᵗʰ year",
+      sublayers: [
+        {
+          title: "1ˢᵗ semester",
+          checkboxes: getCheckBoxes()[6],
+        },
+        {
+          title: "2ⁿᵈ semester",
+          sublayers: [
+            {
+              title: "CA",
+              checkboxes: getCheckBoxes()[7].filter((i) =>
+                mei_perfis.mei_ca.includes(i.label)
+              ),
+            },
+            {
+              title: "CG",
+              checkboxes: getCheckBoxes()[7].filter((i) =>
+                mei_perfis.mei_cg.includes(i.label)
+              ),
+            },
+            {
+              title: "CSI",
+              checkboxes: getCheckBoxes()[7].filter((i) =>
+                mei_perfis.mei_csi.includes(i.label)
+              ),
+            },
+            {
+              title: "EA",
+              checkboxes: getCheckBoxes()[7].filter((i) =>
+                mei_perfis.mei_ea.includes(i.label)
+              ),
+            },
+            {
+              title: "EC",
+              checkboxes: getCheckBoxes()[7].filter((i) =>
+                mei_perfis.mei_ec.includes(i.label)
+              ),
+            },
+            {
+              title: "EI",
+              checkboxes: getCheckBoxes()[7].filter((i) =>
+                mei_perfis.mei_ei.includes(i.label)
+              ),
+            },
+            {
+              title: "EL",
+              checkboxes: getCheckBoxes()[7].filter((i) =>
+                mei_perfis.mei_el.includes(i.label)
+              ),
+            },
+            {
+              title: "SD",
+              checkboxes: getCheckBoxes()[7].filter((i) =>
+                mei_perfis.mei_sd.includes(i.label)
+              ),
+            },
+            {
+              title: "SDVM",
+              checkboxes: getCheckBoxes()[7].filter((i) =>
+                mei_perfis.mei_sdvm.includes(i.label)
+              ),
+            },
+            {
+              title: "SDW",
+              checkboxes: getCheckBoxes()[7].filter((i) =>
+                mei_perfis.mei_sdw.includes(i.label)
+              ),
+            },
+            {
+              title: "SI",
+              checkboxes: getCheckBoxes()[7].filter((i) =>
+                mei_perfis.mei_si.includes(i.label)
+              ),
+            },
+            {
+              title: "MFP",
+              checkboxes: getCheckBoxes()[7].filter((i) =>
+                mei_perfis.mei_mfp.includes(i.label)
+              ),
+            },
+            {
+              title: "RNG",
+              checkboxes: getCheckBoxes()[7].filter((i) =>
+                mei_perfis.mei_rng.includes(i.label)
+              ),
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: "5ᵗʰ year",
+      checkboxes: getCheckBoxes()[8],
+    },
+  ];
+
   return (
     <>
       {/* LEI */}
-      <FilterBlock
-        layer1={lei}
-        layer2={semesters}
-        checkBoxes={getCheckBoxes().slice(0, 6)}
-        checked={checked}
-        setChecked={setChecked as (v: number[]) => void}
-        isShifts={false}
-      />
+      <FilterBlock layers={lei} checked={checked} setChecked={setChecked} />
       {/* MEI */}
-      <FilterBlock
-        layer1={mei}
-        layer2={semesters}
-        checkBoxes={getCheckBoxes().slice(6, 9)}
-        checked={checked}
-        setChecked={setChecked as (v: number[]) => void}
-        exception={1}
-        isShifts={false}
-      />
+      <FilterBlock layers={mei} checked={checked} setChecked={setChecked} />
     </>
   );
 };

--- a/components/EventFilters/EventFilters.tsx
+++ b/components/EventFilters/EventFilters.tsx
@@ -24,8 +24,11 @@ const EventFilters = ({
   const handleFilters = info.handleFilters;
 
   useEffect(() => {
-    const storedFilters: ISelectedFilterDTO[] =
+    const storedFiltersData: number[] =
       JSON.parse(localStorage.getItem("checked")) ?? [];
+    const storedFilters: ISelectedFilterDTO[] = storedFiltersData.map((id) => ({
+      id,
+    }));
     setChecked(storedFilters);
     handleFilters(storedFilters);
   }, [setChecked, handleFilters]);
@@ -71,10 +74,6 @@ const EventFilters = ({
   useEffect(() => {
     clearEvents && clearSelection();
   }, [clearEvents, clearSelection]);
-
-  const [activePanels, setActivePanels] = useState<{
-    [key: string]: string;
-  }>({});
 
   const lei: Layer[] = [
     {

--- a/components/FilterBlock/FilterBlock.tsx
+++ b/components/FilterBlock/FilterBlock.tsx
@@ -43,9 +43,11 @@ const RenderLayer = ({
         ? [...checked, isShift ? { id, shift } : { id }]
         : checked.filter((_, idx) => idx !== index);
 
+    const storeUpdated = isShift ? updated : updated.map(({ id }) => id);
+
     setChecked(updated);
     handleFilters(updated);
-    saveState(isShift ? "shifts" : "checked", index === -1 ? updated : []);
+    saveState(isShift ? "shifts" : "checked", index === -1 ? storeUpdated : []);
   };
 
   const isChecked = (id: number, shift?: string) =>
@@ -80,9 +82,11 @@ const RenderLayer = ({
 
     const isShift = items[0].isShift;
 
+    const storeUpdated = isShift ? updated : updated.map(({ id }) => id);
+
     setChecked(updated);
     handleFilters(updated);
-    saveState(isShift ? "shifts" : "checked", allChecked ? [] : updated);
+    saveState(isShift ? "shifts" : "checked", allChecked ? [] : storeUpdated);
   };
 
   const isAllGroupChecked = (items: CheckBox[]) => {

--- a/components/FilterBlock/FilterBlock.tsx
+++ b/components/FilterBlock/FilterBlock.tsx
@@ -47,7 +47,7 @@ const RenderLayer = ({
 
     setChecked(updated);
     handleFilters(updated);
-    saveState(isShift ? "shifts" : "checked", index === -1 ? storeUpdated : []);
+    saveState(isShift ? "shifts" : "checked", storeUpdated);
   };
 
   const isChecked = (id: number, shift?: string) =>
@@ -86,7 +86,7 @@ const RenderLayer = ({
 
     setChecked(updated);
     handleFilters(updated);
-    saveState(isShift ? "shifts" : "checked", allChecked ? [] : storeUpdated);
+    saveState(isShift ? "shifts" : "checked", storeUpdated);
   };
 
   const isAllGroupChecked = (items: CheckBox[]) => {

--- a/components/FilterBlock/FilterBlock.tsx
+++ b/components/FilterBlock/FilterBlock.tsx
@@ -1,408 +1,185 @@
 import { Checkbox, Collapse } from "antd";
 import "antd/dist/reset.css";
-
-import { Fragment } from "react";
-
-import { CheckBoxProps } from "../../types";
+import { Fragment, useEffect, useState } from "react";
+import { CheckBox, CheckBoxProps, Layer } from "../../types";
 import { ISelectedFilterDTO } from "../../dtos";
 import { useAppInfo } from "../../contexts/AppInfoProvider";
 
 type FilterBlockProps = {
-  layer1: string[]; // contains the titles for the collapses of the 1st layer
-  layer2?: string[]; // contains the titles for the collapses of the 2nd layer
-  checkBoxes: CheckBoxProps[][]; // contains the checkboxes information in a universal format
-  exception?: number; // indicates the index of an element from layer1 where the layer2 should be ignored, for example "5th year"
-  checked: number[] | ISelectedFilterDTO[]; // assumes different types when called from ScheduleFilters.tsx and EventFilters.tsx
-  setChecked: (obj: number[] | ISelectedFilterDTO[]) => void; // assumes different types when called from ScheduleFilters.tsx and EventFilters.tsx
-  isShifts: boolean; // used to know if FilterBlock is being called from ScheduleFilters.tsx or EventFilters.tsx
+  layers: Layer[];
+  checked: ISelectedFilterDTO[];
+  setChecked: (obj: ISelectedFilterDTO[]) => void;
 };
 
-const FilterBlock = ({
-  layer1,
-  layer2,
-  checkBoxes,
-  exception,
+const Indicator = () => (
+  <div className="absolute right-5 mt-5 rounded-full bg-blue-200 p-1" />
+);
+
+const RenderLayer = ({
+  layers,
+  prevTitle = "",
   checked,
   setChecked,
-  isShifts,
-}: FilterBlockProps) => {
-  const info = useAppInfo();
+}: {
+  layers: Layer[];
+  prevTitle?: string;
+  checked: ISelectedFilterDTO[];
+  setChecked: (obj: ISelectedFilterDTO[]) => void;
+}) => {
+  const { handleFilters } = useAppInfo();
 
-  // "Select All" checkbox
-  const SelectAll = ({
-    index1,
-    index2,
-  }: {
-    index1: number;
-    index2: number;
-  }) => {
-    const index = index1 * (layer2 ? layer2.length : 1) + index2;
+  const saveState = (key: string, value: unknown) => {
+    localStorage.setItem(key, JSON.stringify(value));
+  };
 
+  const toggleItem = (id: number, shift?: string) => {
+    const isShift = typeof shift !== "undefined";
+    const index = isShift
+      ? checked.findIndex((item) => item.id === id && item.shift === shift)
+      : checked.findIndex((item) => item.id === id);
+
+    const updated =
+      index === -1
+        ? [...checked, isShift ? { id, shift } : { id }]
+        : checked.filter((_, idx) => idx !== index);
+
+    setChecked(updated);
+    handleFilters(updated);
+    saveState(isShift ? "shifts" : "checked", index === -1 ? updated : []);
+  };
+
+  const isChecked = (id: number, shift?: string) =>
+    checked.some((item) =>
+      shift ? item.id === id && item.shift === shift : item.id === id
+    );
+
+  const isGroupChecked = (items: CheckBox[]) => {
+    return items.some(({ id, label, isShift }) =>
+      isChecked(id, isShift ? label : undefined)
+    );
+  };
+
+  const toggleAll = (items: CheckBox[]) => {
+    const allChecked = items.every(({ id, label, isShift }) =>
+      isChecked(id, isShift ? label : undefined)
+    );
+
+    const updated = allChecked
+      ? checked.filter((item) => !items.some(({ id }) => item.id === id))
+      : [
+          ...checked,
+          ...items
+            .filter(
+              ({ id, label, isShift }) =>
+                !isChecked(id, isShift ? label : undefined)
+            )
+            .map(({ id, label, isShift }) =>
+              isShift ? { id, shift: label } : { id }
+            ),
+        ];
+
+    const isShift = items[0].isShift;
+
+    setChecked(updated);
+    handleFilters(updated);
+    saveState(isShift ? "shifts" : "checked", allChecked ? [] : updated);
+  };
+
+  const isAllGroupChecked = (items: CheckBox[]) => {
+    return items.every(({ id, label, isShift }) =>
+      isChecked(id, isShift ? label : undefined)
+    );
+  };
+
+  const RenderCheckBoxList = ({ items }: { items: CheckBox[] }) => {
     return (
-      <>
-        {checkBoxes[index] && checkBoxes[index].length > 1 && (
-          <Fragment key={index + "SelectAllCheckbox"}>
-            <div className="mb-1.5 border-b pb-1.5 font-display font-medium">
+      <div className="flex flex-col gap-2">
+        {items.length > 0 ? (
+          <>
+            {items.length > 1 && (
               <Checkbox
-                onChange={() => handleToggleAll(index)}
-                checked={isAllChecked(index)}
+                onChange={() => toggleAll(items)}
+                checked={isAllGroupChecked(items)}
                 indeterminate={
-                  isSomeLayer1Checked(index) && !isAllChecked(index)
+                  isGroupChecked(items) && !isAllGroupChecked(items)
                 }
+                className="border-b pb-2"
               >
                 Select All
               </Checkbox>
-            </div>
-          </Fragment>
-        )}
-      </>
-    );
-  };
-
-  // GENERAL
-
-  // Creates a list of checkboxes for a specific group
-  const CheckBoxList = ({
-    index1,
-    index2,
-  }: {
-    index1: number;
-    index2: number;
-  }) => {
-    const index = index1 * (layer2 ? layer2.length : 1) + index2;
-
-    return (
-      <>
-        {checkBoxes[index] && checkBoxes[index].length > 0 && (
-          <div className="font-display font-normal">
-            {checkBoxes[index] &&
-              checkBoxes[index].length > 0 &&
-              checkBoxes[index].map((item) => (
-                <Fragment key={item.id + "Checkbox"}>
-                  <div>
-                    <Checkbox
-                      key={item.id + "CheckBox"}
-                      onChange={() => handleToggle(item.id)}
-                      checked={isChecked(item.id)}
-                    >
-                      {item.label}
-                    </Checkbox>
-                  </div>
-                </Fragment>
+            )}
+            <div className="flex flex-col font-normal">
+              {items.map(({ id, label, isShift }) => (
+                <Checkbox
+                  key={id + label}
+                  onChange={() => toggleItem(id, isShift ? label : undefined)}
+                  checked={isChecked(id, isShift ? label : undefined)}
+                >
+                  {label}
+                </Checkbox>
               ))}
-          </div>
+            </div>
+          </>
+        ) : (
+          <p className="text-neutral-400">Information not available.</p>
         )}
-      </>
-    );
-  };
-
-  // Handles the toggle of a checkbox
-  function handleToggle(id: number) {
-    const currentIdIndex = (checked as number[]).indexOf(id);
-    const newCheck: number[] = [...checked] as number[];
-
-    if (currentIdIndex === -1) newCheck.push(id);
-    else newCheck.splice(currentIdIndex, 1);
-
-    setChecked(newCheck);
-    info.handleFilters(newCheck);
-    localStorage.setItem("checked", JSON.stringify(newCheck));
-  }
-
-  // Handles the toggle of the "Select All" checkbox
-  function handleToggleAll(index: number) {
-    let newChecked: number[] = [...checked] as number[];
-
-    if (!isAllChecked(index))
-      checkBoxes[index].map((event) => newChecked.push(event.id));
-    else {
-      newChecked = newChecked.filter(
-        (id) => !checkBoxes[index].find((value) => value.id === id)
-      );
-    }
-
-    setChecked(newChecked);
-    info.handleFilters(newChecked);
-    localStorage.setItem("checked", JSON.stringify(newChecked));
-  }
-
-  // Checks if a certain checkbox is selected (checked)
-  const isChecked = (id: number): boolean => {
-    return (checked as number[]).includes(id);
-  };
-
-  // Checks if all the checkboxes under a specific group are selected (checked)
-  const isAllChecked = (index: number): boolean => {
-    return (
-      checkBoxes[index] &&
-      checkBoxes[index].every((c) => (checked as number[]).includes(c.id))
-    );
-  };
-
-  // Checks if some checkbox that falls under the 2nd layer is selected (checked)
-  const isSomeLayer2Checked = (index: number): boolean => {
-    return (
-      checkBoxes[index] &&
-      checkBoxes[index].some((c) => (checked as number[]).includes(c.id))
-    );
-  };
-
-  // Checks if some checkbox that falls under the 1st layer is selected (checked)
-  const isSomeLayer1Checked = (index: number): boolean => {
-    const indexs: number[] = Array.from(
-      { length: layer2 ? layer2.length : 1 },
-      (v, i) => i
-    );
-
-    return indexs.some((i) =>
-      isSomeLayer2Checked(index * (layer2 ? layer2.length : 1) + i)
-    );
-  };
-
-  // Tiny blue ball, used to indicate that something inside a Collpase is selected
-  const CheckedIndicator = () => {
-    return (
-      <div className="absolute right-20 mt-5 inline-flex h-fit w-fit overflow-hidden">
-        <div className="ml-1 rounded-full bg-blue-200 p-1" />
       </div>
     );
   };
 
-  // Indicates if some checkbox that falls under the 1st layer is selected
-  const Layer1CheckedIndicator = ({ index }: { index: number }) => {
-    const isOn: boolean = isShifts
-      ? isSomeLayer1ShiftChecked(index)
-      : isSomeLayer1Checked(index);
-
-    return isOn && <CheckedIndicator />;
-  };
-
-  // Indicates if some checkbox that falls under the 2nd layer is selected
-  const Layer2CheckedIndicator = ({
-    index1,
-    index2,
-  }: {
-    index1: number;
-    index2: number;
-  }) => {
-    const index = index1 * layer2.length + index2;
-    const isOn: boolean = isShifts
-      ? isSomeLayer2ShiftChecked(index)
-      : isSomeLayer2Checked(index);
-
-    return isOn && <CheckedIndicator />;
-  };
-
-  // USED FOR SCHEDULE
-
-  // Creates a list of checkboxes for a specific subject (only used for Schedule)
-  const ShiftCheckBoxList = ({
-    id,
-    shifts,
-  }: {
-    id: number;
-    shifts: string[];
-  }) => {
-    return (
-      <>
-        {shifts && shifts.length > 0 ? (
-          shifts.map((item) => (
-            <Fragment key={id.toString() + item + "Checkbox"}>
-              <div>
-                <Checkbox
-                  key={item + "CheckBox"}
-                  onChange={() => handleShiftToggle(id, item)}
-                  checked={isShiftChecked(id, item)}
-                >
-                  {item}
-                </Checkbox>
-              </div>
-            </Fragment>
-          ))
-        ) : (
-          <p className="text-neutral-400">Information not available.</p>
-        )}
-      </>
+  const getSublayerCheckboxes = (layer: Layer) => {
+    if (!layer.sublayers) return layer.checkboxes ?? [];
+    return layer.sublayers.reduce(
+      (acc, sl) => [...acc, ...getSublayerCheckboxes(sl)],
+      []
     );
   };
 
-  // Handles the toggle of a checkbox containing a shift (only used for Schedule)
-  function handleShiftToggle(id: number, shift: string) {
-    const currentIdIndex = (checked as ISelectedFilterDTO[]).findIndex(
-      (selectedShift: ISelectedFilterDTO) =>
-        selectedShift.id === id && selectedShift.shift === shift
-    );
-    const newChecked: ISelectedFilterDTO[] = [
-      ...checked,
-    ] as ISelectedFilterDTO[];
-
-    const shiftObj: ISelectedFilterDTO = { id: id, shift: shift };
-    if (currentIdIndex === -1) newChecked.push(shiftObj);
-    else newChecked.splice(currentIdIndex, 1);
-
-    setChecked(newChecked);
-    info.handleFilters(newChecked);
-    localStorage.setItem("shifts", JSON.stringify(newChecked));
-  }
-
-  // Checks if a specific shift is selected (checked) (only used for Schedule)
-  const isShiftChecked = (id: number, shift: string): boolean => {
-    return (checked as ISelectedFilterDTO[]).some((shiftObj) => {
-      return id === shiftObj.id && shift === shiftObj.shift;
-    });
+  const showIndicator = (layer: Layer) => {
+    return isGroupChecked([
+      ...(layer.checkboxes ?? []),
+      ...getSublayerCheckboxes(layer),
+    ]);
   };
 
-  // Checks if some shift under a certain subject is selected (checked) (only used for Schedule)
-  const isSomeSubjectShiftChecked = (id: number): boolean => {
-    return (checked as ISelectedFilterDTO[]).some((s) => s.id === id);
-  };
-
-  // Checks if a shift that falls under a Collapse from the 2nd layer is selected (checked) (only used for Schedule)
-  const isSomeLayer2ShiftChecked = (index: number): boolean => {
-    return (
-      checkBoxes[index] &&
-      checkBoxes[index].some((c) => isSomeSubjectShiftChecked(c.id))
-    );
-  };
-
-  // Checks if a shift that falls under a Collapse from the 1st layer is selected (checked) (only used for Schedule)
-  const isSomeLayer1ShiftChecked = (index: number): boolean => {
-    const indexs: number[] = Array.from(
-      { length: layer2 ? layer2.length : 1 },
-      (v, i) => i
-    );
-
-    return indexs.some((i) =>
-      isSomeLayer2ShiftChecked(index * (layer2 ? layer2.length : 1) + i)
-    );
-  };
-
-  // Indicates if some shift from a specific subject is selected (only used for Schedule)
-  const Layer3CheckedIndicator = ({ id }: { id: number }) => {
-    return isSomeSubjectShiftChecked(id) && <CheckedIndicator />;
-  };
+  if (layers.length === 0)
+    return <p className="text-neutral-400">Information not available.</p>;
 
   return (
-    <div className="select-none rounded-xl ring-1 ring-neutral-100/50 dark:ring-neutral-400/20">
-      <Collapse
-        className="w-full rounded-xl bg-white font-display font-medium shadow-default dark:bg-neutral-800/70"
-        bordered={false}
-        accordion
-      >
-        {layer1 &&
-          layer1.map((item1, index1) => (
-            <Fragment key={item1 + "Fragment1"}>
-              <Layer1CheckedIndicator
-                index={index1}
-                key={item1 + "Layer1CheckedIndicator"}
+    <Collapse
+      bordered={false}
+      accordion
+      className="relative bg-white font-display dark:bg-[#212121]"
+    >
+      {layers.map((layer) => (
+        <Fragment key={prevTitle + layer.title}>
+          {showIndicator(layer) && <Indicator />}
+          <Collapse.Panel header={layer.title} key={prevTitle + layer.title}>
+            {layer.checkboxes && (
+              <RenderCheckBoxList items={layer.checkboxes} />
+            )}
+            {layer.sublayers && (
+              <RenderLayer
+                layers={layer.sublayers}
+                checked={checked}
+                setChecked={setChecked}
               />
-              <Collapse.Panel header={item1} key={item1 + "Panel"}>
-                <Collapse
-                  className="bg-white font-display font-medium dark:bg-inherit"
-                  bordered={false}
-                  accordion
-                  key={item1 + "Collapse"}
-                >
-                  {layer2 && index1 !== exception ? (
-                    layer2.map((item2, index2) => (
-                      <Fragment key={item2 + "Fragment2"}>
-                        <Layer2CheckedIndicator
-                          index1={index1}
-                          index2={index2}
-                          key={item1 + item2 + "Layer2CheckedIndicator"}
-                        />
-                        <Collapse.Panel
-                          header={item2}
-                          key={item1 + item2 + "Panel"}
-                        >
-                          <Collapse
-                            className="bg-white font-display font-normal dark:bg-inherit"
-                            bordered={false}
-                            accordion
-                            key={item1 + item2 + "Collapse"}
-                          >
-                            {checkBoxes[index1 * layer2.length + index2] &&
-                            checkBoxes[index1 * layer2.length + index2].some(
-                              (item) => item.shifts && item.shifts.length > 0
-                            ) ? (
-                              <>
-                                {checkBoxes[
-                                  index1 * (layer2 ? layer2.length : 1) + index2
-                                ].map((item3) => (
-                                  <Fragment key={item3 + "Fragment3"}>
-                                    <Layer3CheckedIndicator
-                                      id={item3.id}
-                                      key={item3.id + "Layer3CheckedIndicator"}
-                                    />
-                                    <Collapse.Panel
-                                      header={item3.label}
-                                      key={item3.id + "Panel"}
-                                    >
-                                      <ShiftCheckBoxList
-                                        id={item3.id}
-                                        shifts={item3.shifts}
-                                        key={item3.id + "ShiftCheckBoxList"}
-                                      />
-                                    </Collapse.Panel>
-                                  </Fragment>
-                                ))}
-                              </>
-                            ) : checkBoxes[
-                                index1 * layer2.length + index2
-                              ].some((item) => item.shifts) ? (
-                              <p className="text-neutral-400">
-                                Information not available.
-                              </p>
-                            ) : (
-                              <>
-                                <SelectAll
-                                  index1={index1}
-                                  index2={index2}
-                                  key={item2 + "SelectAll"}
-                                />
-                                <CheckBoxList
-                                  index1={index1}
-                                  index2={index2}
-                                  key={item2 + "CheckBoxList"}
-                                />
-                              </>
-                            )}
-                          </Collapse>
-                        </Collapse.Panel>
-                      </Fragment>
-                    ))
-                  ) : index1 === exception ? (
-                    <>
-                      <SelectAll
-                        index1={index1}
-                        index2={0}
-                        key={item1 + "SelectAll"}
-                      />
-                      <CheckBoxList
-                        index1={index1}
-                        index2={0}
-                        key={item1 + "CheckBoxList"}
-                      />
-                    </>
-                  ) : (
-                    <>
-                      <SelectAll
-                        index1={0}
-                        index2={index1}
-                        key={item1 + "SelectAll"}
-                      />
-                      <CheckBoxList
-                        index1={0}
-                        index2={index1}
-                        key={item1 + "CheckBoxList"}
-                      />
-                    </>
-                  )}
-                </Collapse>
-              </Collapse.Panel>
-            </Fragment>
-          ))}
-      </Collapse>
+            )}
+          </Collapse.Panel>
+        </Fragment>
+      ))}
+    </Collapse>
+  );
+};
+
+const FilterBlock = ({ layers, checked, setChecked }: FilterBlockProps) => {
+  return (
+    <div className="overflow-hidden rounded-xl ring-1 ring-neutral-100/50 dark:ring-neutral-400/20">
+      <RenderLayer
+        layers={layers || []}
+        checked={checked}
+        setChecked={setChecked}
+      />
     </div>
   );
 };

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -7,12 +7,13 @@ import Head from "next/head";
 import Image from "next/image";
 import { AppInfoProvider } from "../../contexts/AppInfoProvider";
 import MoreButton from "../MoreButton";
+import { ISelectedFilterDTO } from "../../dtos";
 
 interface ILayoutProps {
   children: ReactNode;
   isEvents: boolean;
   filters: any;
-  handleFilters: any;
+  handleFilters: (filters: ISelectedFilterDTO[]) => void;
   fetchTheme: () => void;
   handleData?: (_: boolean) => void;
 }

--- a/components/ScheduleFilters/ScheduleFilters.tsx
+++ b/components/ScheduleFilters/ScheduleFilters.tsx
@@ -3,13 +3,14 @@ import { useCallback, useEffect } from "react";
 import { IFilterDTO, ISelectedFilterDTO } from "../../dtos";
 
 import FilterBlock from "../FilterBlock";
-import { CheckBoxProps } from "../../types";
+import { CheckBoxProps, Layer } from "../../types";
 import { useAppInfo } from "../../contexts/AppInfoProvider";
+import * as mei_perfis from "../../data/mei_perfis";
 
 interface ISelectScheduleProps {
   clearSchedule: boolean;
-  checked: number[] | ISelectedFilterDTO[];
-  setChecked: (obj: number[] | ISelectedFilterDTO[]) => void;
+  checked: ISelectedFilterDTO[];
+  setChecked: (obj: ISelectedFilterDTO[]) => void;
 }
 
 const ScheduleFilters = ({
@@ -22,7 +23,8 @@ const ScheduleFilters = ({
   const handleFilters = info.handleFilters;
 
   useEffect(() => {
-    const stored = JSON.parse(localStorage.getItem("shifts")) ?? [];
+    const stored: { id: number; shift: string }[] =
+      JSON.parse(localStorage.getItem("shifts")) ?? [];
     setChecked(stored);
     handleFilters(stored);
   }, [handleFilters, setChecked]);
@@ -79,12 +81,6 @@ const ScheduleFilters = ({
 
   filtersByGroup[9] = filters.filter((f) => f.groupId === 0); // others
 
-  const mei = ["4ᵗʰ year"];
-
-  const lei = ["1ˢᵗ year", "2ⁿᵈ year", "3ʳᵈ year"];
-
-  const semesters = ["1ˢᵗ semester", "2ⁿᵈ semester"];
-
   // Converts all filter information into the universal format used by FilterBlock
   function getCheckBoxes(): CheckBoxProps[][] {
     const checkBoxes: CheckBoxProps[][] = [];
@@ -106,26 +102,185 @@ const ScheduleFilters = ({
     return checkBoxes;
   }
 
+  const mapToCheckbox = (items: CheckBoxProps[]) =>
+    items.map((item) => ({
+      title: item.label,
+      checkboxes: item.shifts.map((shift) => ({
+        id: item.id,
+        label: shift,
+        isShift: true,
+      })),
+    }));
+
+  const lei: Layer[] = [
+    {
+      title: "1ˢᵗ year",
+      sublayers: [
+        {
+          title: "1ˢᵗ semester",
+          sublayers: mapToCheckbox(getCheckBoxes()[0]),
+        },
+        {
+          title: "2ⁿᵈ semester",
+          sublayers: mapToCheckbox(getCheckBoxes()[1]),
+        },
+      ],
+    },
+    {
+      title: "2ⁿᵈ year",
+      sublayers: [
+        {
+          title: "1ˢᵗ semester",
+          sublayers: mapToCheckbox(getCheckBoxes()[2]),
+        },
+        {
+          title: "2ⁿᵈ semester",
+          sublayers: mapToCheckbox(getCheckBoxes()[3]),
+        },
+      ],
+    },
+    {
+      title: "3ʳᵈ year",
+      sublayers: [
+        {
+          title: "1ˢᵗ semester",
+          sublayers: mapToCheckbox(getCheckBoxes()[4]),
+        },
+        {
+          title: "2ⁿᵈ semester",
+          sublayers: mapToCheckbox(getCheckBoxes()[5]),
+        },
+      ],
+    },
+  ];
+
+  const mei: Layer[] = [
+    {
+      title: "4ᵗʰ year",
+      sublayers: [
+        {
+          title: "1ˢᵗ semester",
+          sublayers: mapToCheckbox(getCheckBoxes()[6]),
+        },
+        {
+          title: "2ⁿᵈ semester",
+          sublayers: [
+            {
+              title: "CA",
+              sublayers: mapToCheckbox(
+                getCheckBoxes()[7].filter((i) =>
+                  mei_perfis.mei_ca.includes(i.label)
+                )
+              ),
+            },
+            {
+              title: "CG",
+              sublayers: mapToCheckbox(
+                getCheckBoxes()[7].filter((i) =>
+                  mei_perfis.mei_cg.includes(i.label)
+                )
+              ),
+            },
+            {
+              title: "CSI",
+              sublayers: mapToCheckbox(
+                getCheckBoxes()[7].filter((i) =>
+                  mei_perfis.mei_csi.includes(i.label)
+                )
+              ),
+            },
+            {
+              title: "EA",
+              sublayers: mapToCheckbox(
+                getCheckBoxes()[7].filter((i) =>
+                  mei_perfis.mei_ea.includes(i.label)
+                )
+              ),
+            },
+            {
+              title: "EC",
+              sublayers: mapToCheckbox(
+                getCheckBoxes()[7].filter((i) =>
+                  mei_perfis.mei_ec.includes(i.label)
+                )
+              ),
+            },
+            {
+              title: "EI",
+              sublayers: mapToCheckbox(
+                getCheckBoxes()[7].filter((i) =>
+                  mei_perfis.mei_ei.includes(i.label)
+                )
+              ),
+            },
+            {
+              title: "EL",
+              sublayers: mapToCheckbox(
+                getCheckBoxes()[7].filter((i) =>
+                  mei_perfis.mei_el.includes(i.label)
+                )
+              ),
+            },
+            {
+              title: "SD",
+              sublayers: mapToCheckbox(
+                getCheckBoxes()[7].filter((i) =>
+                  mei_perfis.mei_sd.includes(i.label)
+                )
+              ),
+            },
+            {
+              title: "SDVM",
+              sublayers: mapToCheckbox(
+                getCheckBoxes()[7].filter((i) =>
+                  mei_perfis.mei_sdvm.includes(i.label)
+                )
+              ),
+            },
+            {
+              title: "SDW",
+              sublayers: mapToCheckbox(
+                getCheckBoxes()[7].filter((i) =>
+                  mei_perfis.mei_sdw.includes(i.label)
+                )
+              ),
+            },
+            {
+              title: "SI",
+              sublayers: mapToCheckbox(
+                getCheckBoxes()[7].filter((i) =>
+                  mei_perfis.mei_si.includes(i.label)
+                )
+              ),
+            },
+            {
+              title: "MFP",
+              sublayers: mapToCheckbox(
+                getCheckBoxes()[7].filter((i) =>
+                  mei_perfis.mei_mfp.includes(i.label)
+                )
+              ),
+            },
+            {
+              title: "RNG",
+              sublayers: mapToCheckbox(
+                getCheckBoxes()[7].filter((i) =>
+                  mei_perfis.mei_rng.includes(i.label)
+                )
+              ),
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
   return (
     <>
       {/* LEI */}
-      <FilterBlock
-        layer1={lei}
-        layer2={semesters}
-        checkBoxes={getCheckBoxes().slice(0, 6)}
-        checked={checked}
-        setChecked={setChecked as (v: ISelectedFilterDTO[]) => void}
-        isShifts
-      />
+      <FilterBlock layers={lei} checked={checked} setChecked={setChecked} />
       {/* MEI */}
-      <FilterBlock
-        layer1={mei}
-        layer2={semesters}
-        checkBoxes={getCheckBoxes().slice(6, 9)}
-        checked={checked}
-        setChecked={setChecked as (v: ISelectedFilterDTO[]) => void}
-        isShifts
-      />
+      <FilterBlock layers={mei} checked={checked} setChecked={setChecked} />
     </>
   );
 };

--- a/components/ScheduleFilters/ScheduleFilters.tsx
+++ b/components/ScheduleFilters/ScheduleFilters.tsx
@@ -118,7 +118,13 @@ const ScheduleFilters = ({
       sublayers: [
         {
           title: "1ˢᵗ semester",
-          sublayers: mapToCheckbox(getCheckBoxes()[0]),
+          sublayers: [
+            ...mapToCheckbox(getCheckBoxes()[0]).slice(0, 5),
+            {
+              title: "Opção UMinho",
+              sublayers: mapToCheckbox(getCheckBoxes()[0]).slice(5),
+            },
+          ],
         },
         {
           title: "2ⁿᵈ semester",

--- a/components/ShareButton/ShareButton.tsx
+++ b/components/ShareButton/ShareButton.tsx
@@ -4,7 +4,7 @@ import { ISelectedFilterDTO } from "../../dtos";
 import { useAppInfo } from "../../contexts/AppInfoProvider";
 
 type ShareButtonProps = {
-  setChecked: (obj: number[] | ISelectedFilterDTO[]) => void;
+  setChecked: (obj: ISelectedFilterDTO[]) => void;
 };
 
 const ShareButton = ({ setChecked }: ShareButtonProps) => {

--- a/components/ShareModal/ShareModal.tsx
+++ b/components/ShareModal/ShareModal.tsx
@@ -10,7 +10,7 @@ import { useAppInfo } from "../../contexts/AppInfoProvider";
 type ShareModalProps = {
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
-  setChecked: (obj: number[] | ISelectedFilterDTO[]) => void;
+  setChecked: (obj: ISelectedFilterDTO[]) => void;
 };
 
 const ShareModal = ({ isOpen, setIsOpen, setChecked }: ShareModalProps) => {
@@ -91,9 +91,10 @@ const ShareModal = ({ isOpen, setIsOpen, setChecked }: ShareModalProps) => {
    * If any event is invalid, the function returns undefined
    * @param eventsString
    */
-  function parseEvents(eventsString: string): number[] | undefined {
+  function parseEvents(eventsString: string): ISelectedFilterDTO[] | undefined {
     const events = eventsString.split("&").map(parseEventValid);
-    return events.every(isValidId) ? events : undefined;
+    const formatedEvents = events.map((id) => ({ id }));
+    return events.every(isValidId) ? formatedEvents : undefined;
   }
 
   const groupBy = <T, K extends keyof any>(list: T[], getKey: (item: T) => K) =>

--- a/components/ShareModal/ShareModal.tsx
+++ b/components/ShareModal/ShareModal.tsx
@@ -189,7 +189,9 @@ const ShareModal = ({ isOpen, setIsOpen, setChecked }: ShareModalProps) => {
     setChecked(parsedData);
     localStorage.setItem(
       info.isEvents ? "checked" : "shifts",
-      JSON.stringify(parsedData)
+      JSON.stringify(
+        info.isEvents ? parsedData.map(({ id }) => id) : parsedData
+      )
     );
     playValidImportAnimation();
   }

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -20,7 +20,7 @@ type SidebarProps = {
 const Sidebar = ({ isOpen, setIsOpen }: SidebarProps) => {
   const [isSettings, setIsSettings] = useState(false);
   const [clear, setClear] = useState(false);
-  const [checked, setChecked] = useState<number[] | ISelectedFilterDTO[]>([]);
+  const [checked, setChecked] = useState<ISelectedFilterDTO[]>([]);
   const [promptInstall, setPromptInstall] =
     useState<BeforeInstallPromptEvent>(null);
   const [animateRefresh, setAnimateRefresh] = useState<boolean>(false);

--- a/components/Themes/Themes.tsx
+++ b/components/Themes/Themes.tsx
@@ -92,9 +92,8 @@ const Themes = ({ isOpen, setIsOpen }: ThemesProps) => {
   }
 
   const initializeVariables = useCallback(() => {
-    const checkedFiltersData: ISelectedFilterDTO[] =
+    const checkedFilters: number[] =
       JSON.parse(localStorage.getItem("checked")) ?? [];
-    const checkedFilters = checkedFiltersData.map((f) => f.id);
     const checkedShifts: { id: number; shift: string }[] = JSON.parse(
       localStorage.getItem("shifts")
     );

--- a/components/Themes/Themes.tsx
+++ b/components/Themes/Themes.tsx
@@ -1,7 +1,7 @@
 import { Switch } from "@headlessui/react";
 import { useCallback, useEffect, useState } from "react";
 import { HexColorPicker, HexColorInput } from "react-colorful";
-import { IFilterDTO } from "../../dtos";
+import { IFilterDTO, ISelectedFilterDTO } from "../../dtos";
 import {
   reduceOpacity,
   useColorTheme,
@@ -92,8 +92,9 @@ const Themes = ({ isOpen, setIsOpen }: ThemesProps) => {
   }
 
   const initializeVariables = useCallback(() => {
-    const checkedFilters: number[] =
+    const checkedFiltersData: ISelectedFilterDTO[] =
       JSON.parse(localStorage.getItem("checked")) ?? [];
+    const checkedFilters = checkedFiltersData.map((f) => f.id);
     const checkedShifts: { id: number; shift: string }[] = JSON.parse(
       localStorage.getItem("shifts")
     );

--- a/contexts/AppInfoProvider.tsx
+++ b/contexts/AppInfoProvider.tsx
@@ -4,7 +4,7 @@ import { IFilterDTO, ISelectedFilterDTO } from "../dtos";
 interface AppInfoContextData {
   isEvents: boolean;
   filters: number[] | IFilterDTO[];
-  handleFilters: (filters: number[] | ISelectedFilterDTO[]) => void;
+  handleFilters: (filters: ISelectedFilterDTO[]) => void;
   fetchTheme: () => void;
   image: string;
   handleData: (_: boolean) => void;

--- a/data/mei_perfis.ts
+++ b/data/mei_perfis.ts
@@ -1,0 +1,13 @@
+export const mei_ca = ["CHED", "ADGD", "SAD"];
+export const mei_cg = ["VI", "VTR", "VCPI"];
+export const mei_csi = ["TS", "EC", "ES"];
+export const mei_ea = ["SIC", "AA", "ABD"];
+export const mei_ec = ["MD", "BD NoSQL", "AISBD"];
+export const mei_ei = ["GSR", "IRIP", "QSI"];
+export const mei_el = ["EG", "RPCW", "SPLN"];
+export const mei_sd = ["TF", "SDGE", "PSD"];
+export const mei_sdvm = ["TDS", "MES", "EES"];
+export const mei_sdw = ["SETCD", "CIAD", "ACAD"];
+export const mei_si = ["SA", "AProf", "ASM"];
+export const mei_mfp = ["VF", "PCF", "CSI"];
+export const mei_rng = ["RFM", "RDS", "NPR"];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,7 +13,7 @@ import Layout from "../components/Layout";
 import EventModal from "../components/EventModal";
 import CustomToolbar from "../components/CustomToolbar";
 import styles from "../styles/events.module.css";
-import { IEventDTO } from "../dtos";
+import { IEventDTO, ISelectedFilterDTO } from "../dtos";
 import useColorTheme from "../hooks/useColorTheme";
 
 const localizer = momentLocalizer(moment);
@@ -85,7 +85,9 @@ export default function Home({ filters }) {
      *
      * this is why we go to the localStorage, which is normally the responsibility of EventFilters.
      */
-    const stored: number[] = JSON.parse(localStorage.getItem("checked")) ?? [];
+    const storedData: ISelectedFilterDTO[] =
+      JSON.parse(localStorage.getItem("checked")) ?? [];
+    const stored = storedData.map((f) => f.id);
     let newEvents = [...data];
     if (stored.length > 0) {
       newEvents = newEvents.filter(
@@ -96,7 +98,7 @@ export default function Home({ filters }) {
   }, []);
 
   const handleFilters = useCallback(
-    (myFilters: number[]) => {
+    (myFilters: ISelectedFilterDTO[]) => {
       const showNewEvents = (filters: number[]) => {
         let newEvents = [...fetchedEvents];
 
@@ -108,8 +110,8 @@ export default function Home({ filters }) {
 
         setEvents(newEvents);
       };
-      setFilters(myFilters);
-      showNewEvents(myFilters);
+      setFilters(myFilters.map((f) => f.id));
+      showNewEvents(myFilters.map((f) => f.id));
     },
     [fetchedEvents]
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -85,9 +85,7 @@ export default function Home({ filters }) {
      *
      * this is why we go to the localStorage, which is normally the responsibility of EventFilters.
      */
-    const storedData: ISelectedFilterDTO[] =
-      JSON.parse(localStorage.getItem("checked")) ?? [];
-    const stored = storedData.map((f) => f.id);
+    const stored: number[] = JSON.parse(localStorage.getItem("checked")) ?? [];
     let newEvents = [...data];
     if (stored.length > 0) {
       newEvents = newEvents.filter(

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,6 +9,18 @@ export type CheckBoxProps = {
   shifts?: string[];
 };
 
+export interface CheckBox {
+  id: number;
+  label: string;
+  isShift?: boolean;
+}
+
+export interface Layer {
+  title: string;
+  sublayers?: Layer[];
+  checkboxes?: CheckBox[];
+}
+
 export interface BeforeInstallPromptEvent extends Event {
   readonly platforms: Array<string>;
 


### PR DESCRIPTION
Refactored `FilterBlock` in order to **completely generalize its usage** and allow for the long awaited **separation of "Opção UMinho" subjects from the regular ones** and the **organization of the subjects of each profile in the master's degree** in its own category.

| | |
| - | - |
| ![image](https://github.com/user-attachments/assets/f22bf1ce-b980-4c66-bd4a-37040a9c4028) | ![image](https://github.com/user-attachments/assets/25fae2e6-6bbe-43fa-a809-17181d8907fe) |

This refactor was made possible by using a **recursive** component, `RenderLayer`, that calls itself for each sublayer. This component receives information in the following specification, that itself is also recursive:

```ts
export interface Layer {
  title: string;
  sublayers?: Layer[];
  checkboxes?: CheckBox[];
}
```

The stopping condition of the recursive component is reaching a layer that has `checkboxes` specified. This allows us to have whatever amount of nested layers we want and even mix sublayers with checkboxes. For example, this is what the structure looks like for 1st year, 1st semester:

```tsx
{
   title: "1ˢᵗ year",
   sublayers: [
     {
       title: "1ˢᵗ semester",
       checkboxes: getCheckBoxes()[0].slice(0, 5),
       sublayers: [
         {
           title: "Opção UMinho",
           checkboxes: getCheckBoxes()[0].slice(5),
         },
       ],
     },
     {
       title: "2ⁿᵈ semester",
       checkboxes: getCheckBoxes()[1],
     },
  ],
}
```

Notice how we have an extra sublayer on the first semester and not on the second one. This data structure gives us full liberty of what to place in the filters, what titles to give each specific layer, etc., which didn't happen before.

There were also improvements to the checkbox toggle functions so that they were generalized for events and shifts, etc.

**The file went from 400 lines to just under 200 :D** 🚀 

Thanks to the generalization, **Select All** is now available for everything so we can now select all shifts of a specific subject, for example.